### PR TITLE
chore: add Hetzner OpenTofu deployment foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+- Add durable project-specific notes here as they are discovered through real work.
+- OpenTofu infrastructure is the source of truth under `infra/`; host and Compose deployment assets are under `deploy/`. Use the attended commands in those directories and keep state, plans, and host-only environment files untracked.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,0 +1,11 @@
+# Copy to deploy/.env on the host. Never commit deploy/.env.
+# Use an immutable backend image reference, preferably a digest.
+BACKEND_IMAGE=ghcr.io/your-org/eddies-wallet-backend@sha256:REPLACE_WITH_DIGEST
+SITE_ADDRESS=example.invalid
+POSTGRES_DB=eddies_wallet
+POSTGRES_USER=eddies_wallet
+POSTGRES_PASSWORD=SET_ON_HOST_ONLY
+# The application must read these same connection values from its environment.
+DATABASE_URL=postgresql://eddies_wallet:SET_ON_HOST_ONLY@db:5432/eddies_wallet
+# Required by the migration command on the host. Keep the command explicit.
+MIGRATION_COMMAND=./bin/migrate

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -1,0 +1,4 @@
+.env
+*.env
+*.key
+*.pem

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,6 @@
+# Set SITE_ADDRESS to a real domain in the host-only .env only after DNS and
+# the captain's TLS/email decisions are complete. This placeholder deliberately
+# does not configure production DNS or certificates.
+{$SITE_ADDRESS} {
+  reverse_proxy backend:8080
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,59 @@
+# Eddie's Wallet deployment foundation
+
+This directory is the vendor-neutral deployment contract for the first
+low-cost development host. The host is intentionally empty of product code
+until a backend image is selected and reviewed.
+
+## Files
+
+- `bootstrap.sh` hardens a fresh Ubuntu LTS host, creates the non-root
+  `eddies` deployment user, enables unattended security updates, installs a
+  held Ubuntu Docker engine and Compose v2, and restricts host ingress.
+- `compose.yaml` is the single project boundary: Caddy is the only service
+  with HTTP/HTTPS ports, the backend is internal to the Compose networks, and
+  Postgres has no host port.
+- `Caddyfile` is a domain placeholder. Set `SITE_ADDRESS` only after a domain,
+  DNS, and explicit TLS/email decisions exist. This repository does not create
+  DNS records or certificates.
+- `.env.example` documents required names. Copy it to the host as `.env`,
+  replace every placeholder there, and never commit `.env`.
+- `deploy.sh`, `migrate.sh`, `rollback.sh`, and `healthcheck.sh` are the
+  operator commands. All server addresses and commands are invocation-time
+  values, not tracked configuration.
+- `nightly-encrypted-export.sh` is installed behind a systemd timer. It pipes a
+  database dump through gzip and age to an independent HTTPS PUT destination.
+
+## First host setup
+
+1. Provision a fresh Ubuntu LTS host with only the intended SSH public key and
+   the dedicated provider firewall. Pass the current operator CIDR to
+   `bootstrap.sh`; do not use a broad SSH rule as a convenience.
+2. The bootstrap creates the `eddies` user and disables root/password SSH. The
+   deployment key is copied from the initial root `authorized_keys` file, so no
+   new private key is generated.
+3. Copy this directory with `REMOTE_HOST` set in the invoking shell. Create the
+   host-only `deploy/.env` from `.env.example`, using an immutable backend image
+   reference and real database credentials only on the host.
+4. Set `MIGRATION_COMMAND` to the backend's reviewed migration command and run
+   `migrate.sh` before `deploy.sh` starts the Compose project.
+5. Set `HEALTHCHECK_URL` to the later domain's health endpoint and run
+   `healthcheck.sh` after deployment.
+
+Example command shapes, with placeholders intentionally left unresolved:
+
+```sh
+REMOTE_HOST='<server-address>' REMOTE_USER=eddies ./deploy/deploy.sh
+REMOTE_HOST='<server-address>' MIGRATION_COMMAND='./bin/migrate' ./deploy/migrate.sh
+HEALTHCHECK_URL='https://<domain>/healthz' ./deploy/healthcheck.sh
+REMOTE_HOST='<server-address>' ROLLBACK_BACKEND_IMAGE='<old-immutable-image>' ./deploy/rollback.sh
+```
+
+## Recovery boundary
+
+The nightly timer must not be considered configured until
+`/etc/eddies-wallet/backup.env` exists with mode `0600`,
+`BACKUP_DESTINATION` points to an independent HTTPS destination, and
+`BACKUP_AGE_RECIPIENT` is a real age recipient. If any of those prerequisites
+are absent, the job exits with a visible `STOPPED` message and does not create
+a same-disk dump. No object storage, backup account, DNS, TLS certificate, or
+third-party service is provisioned by this repository.

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Bootstrap a fresh Ubuntu LTS host for Eddie's Wallet.
+# Run as root from Hetzner user-data or an attended root shell.
+set -Eeuo pipefail
+
+SSH_ADMIN_CIDR="${SSH_ADMIN_CIDR:?Set SSH_ADMIN_CIDR to the operator address before bootstrapping}"
+DEPLOY_USER="${DEPLOY_USER:-eddies}"
+export DEBIAN_FRONTEND=noninteractive
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "bootstrap must run as root" >&2
+  exit 1
+fi
+
+apt-get update
+apt-get -y upgrade
+apt-get install -y --no-install-recommends \
+  age \
+  ca-certificates \
+  curl \
+  docker-compose-v2 \
+  docker.io \
+  fail2ban \
+  sudo \
+  unattended-upgrades \
+  ufw
+
+# Hold the distribution-provided Docker engine and Compose plugin so a routine
+# security update cannot silently change the container runtime contract.
+apt-mark hold docker.io docker-compose-v2
+systemctl enable --now docker
+
+if ! id -u "$DEPLOY_USER" >/dev/null 2>&1; then
+  useradd --create-home --shell /bin/bash "$DEPLOY_USER"
+fi
+usermod -aG docker "$DEPLOY_USER"
+cat >/etc/sudoers.d/eddies-wallet <<EOF
+$DEPLOY_USER ALL=(root) NOPASSWD: /usr/bin/install, /usr/bin/systemctl start eddies-wallet-backup.timer
+EOF
+chmod 0440 /etc/sudoers.d/eddies-wallet
+visudo -cf /etc/sudoers.d/eddies-wallet
+install -d -m 0700 -o "$DEPLOY_USER" -g "$DEPLOY_USER" "/home/$DEPLOY_USER/.ssh"
+if [[ -s /root/.ssh/authorized_keys ]]; then
+  install -m 0600 -o "$DEPLOY_USER" -g "$DEPLOY_USER" /root/.ssh/authorized_keys "/home/$DEPLOY_USER/.ssh/authorized_keys"
+else
+  echo "No root authorized_keys were found; refusing to disable root SSH" >&2
+  exit 1
+fi
+
+install -d -m 0750 -o root -g "$DEPLOY_USER" /etc/eddies-wallet
+cat >/etc/eddies-wallet/backup.env.example <<'EOF'
+# Copy to /etc/eddies-wallet/backup.env with mode 0600 on the host.
+# The destination must be an independent HTTPS endpoint that accepts PUT.
+# Do not use a local path or a same-host URL as an off-site backup.
+# BACKUP_DESTINATION=https://backup.example.invalid/eddies-wallet
+# BACKUP_AGE_RECIPIENT=age1replace-this-with-a-real-recipient
+# COMPOSE_DIR=/opt/eddies-wallet/deploy
+EOF
+chmod 0640 /etc/eddies-wallet/backup.env.example
+
+cat >/etc/apt/apt.conf.d/20auto-upgrades <<'EOF'
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Unattended-Upgrade "1";
+EOF
+
+cat >/etc/fail2ban/jail.d/eddies-wallet-sshd.local <<'EOF'
+[sshd]
+enabled = true
+backend = systemd
+bantime = 1h
+findtime = 10m
+maxretry = 5
+EOF
+systemctl enable --now fail2ban
+
+# The provider firewall is the primary boundary. UFW provides a second,
+# host-local boundary in case the provider rule is ever changed accidentally.
+ufw --force reset
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow from "$SSH_ADMIN_CIDR" to any port 22 proto tcp comment 'operator SSH only'
+ufw allow 80/tcp comment 'future HTTP reverse proxy'
+ufw allow 443/tcp comment 'future HTTPS reverse proxy'
+ufw --force enable
+
+install -d -m 0755 /etc/ssh/sshd_config.d
+cat >/etc/ssh/sshd_config.d/eddies-wallet-hardening.conf <<EOF
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+ChallengeResponseAuthentication no
+PubkeyAuthentication yes
+AuthenticationMethods publickey
+PermitRootLogin no
+AllowUsers $DEPLOY_USER
+X11Forwarding no
+AllowAgentForwarding no
+EOF
+sshd -t
+systemctl reload ssh
+
+# Leave the deployment project stopped. The repository deployment assets are
+# copied here separately after this bootstrap has completed.
+install -d -m 0755 -o "$DEPLOY_USER" -g "$DEPLOY_USER" /opt/eddies-wallet/deploy
+cat >/etc/systemd/system/eddies-wallet-backup.service <<'EOF'
+[Unit]
+Description=Nightly encrypted Eddie's Wallet database export
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+User=root
+ExecStart=/opt/eddies-wallet/deploy/nightly-encrypted-export.sh
+EOF
+cat >/etc/systemd/system/eddies-wallet-backup.timer <<'EOF'
+[Unit]
+Description=Run the Eddie's Wallet encrypted export nightly
+
+[Timer]
+OnCalendar=*-*-* 02:30:00 UTC
+Persistent=true
+RandomizedDelaySec=15m
+
+[Install]
+WantedBy=timers.target
+EOF
+systemctl daemon-reload
+systemctl enable eddies-wallet-backup.timer
+
+printf 'Bootstrap complete. Deploy assets to /opt/eddies-wallet/deploy and configure /etc/eddies-wallet/backup.env before starting the backup timer.\n'

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -1,0 +1,69 @@
+name: eddies-wallet
+
+services:
+  proxy:
+    image: caddy:2.9.1-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - caddy-data:/data
+      - caddy-config:/config
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+    networks:
+      - edge
+    depends_on:
+      backend:
+        condition: service_healthy
+
+  backend:
+    # Use an immutable registry reference, normally an image digest.
+    image: ${BACKEND_IMAGE:?Set BACKEND_IMAGE in the host-only .env}
+    restart: unless-stopped
+    env_file:
+      - .env
+    expose:
+      - "8080"
+    networks:
+      - edge
+      - private
+    depends_on:
+      db:
+        condition: service_healthy
+    read_only: true
+    tmpfs:
+      - /tmp
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O - http://127.0.0.1:8080/healthz || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+  db:
+    image: postgres:16.4-alpine
+    restart: unless-stopped
+    env_file:
+      - .env
+    expose:
+      - "5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    networks:
+      - private
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  caddy-data:
+  caddy-config:
+  postgres-data:
+
+networks:
+  edge:
+  private:
+    internal: true

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REMOTE_HOST="${REMOTE_HOST:?Set REMOTE_HOST at invocation time; do not commit an address}"
+REMOTE_USER="${REMOTE_USER:-eddies}"
+REMOTE_DIR="${REMOTE_DIR:-/opt/eddies-wallet/deploy}"
+LOCAL_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new "$REMOTE_USER@$REMOTE_HOST" \
+  "test -d '$REMOTE_DIR' || { echo 'bootstrap has not created $REMOTE_DIR' >&2; exit 1; }"
+
+# .env is deliberately excluded. It is created and managed only on the host.
+tar -C "$LOCAL_DIR" \
+  --exclude='./.env' \
+  --exclude='./.git' \
+  -cf - . \
+  | ssh -o BatchMode=yes "$REMOTE_USER@$REMOTE_HOST" "tar -xf - -C '$REMOTE_DIR'"
+
+ssh -o BatchMode=yes "$REMOTE_USER@$REMOTE_HOST" "test -f '$REMOTE_DIR/.env' || { echo 'missing host-only $REMOTE_DIR/.env' >&2; exit 1; }"
+ssh -o BatchMode=yes "$REMOTE_USER@$REMOTE_HOST" \
+  "sudo install -m 0755 '$REMOTE_DIR/nightly-encrypted-export.sh' /opt/eddies-wallet/deploy/nightly-encrypted-export.sh && sudo systemctl start eddies-wallet-backup.timer"
+
+MIGRATION_COMMAND="${MIGRATION_COMMAND:?Set MIGRATION_COMMAND to the reviewed backend migration command}"
+REMOTE_HOST="$REMOTE_HOST" REMOTE_USER="$REMOTE_USER" REMOTE_DIR="$REMOTE_DIR" MIGRATION_COMMAND="$MIGRATION_COMMAND" \
+  "$LOCAL_DIR/migrate.sh"
+ssh -o BatchMode=yes "$REMOTE_USER@$REMOTE_HOST" \
+  "docker compose --project-directory '$REMOTE_DIR' --file '$REMOTE_DIR/compose.yaml' pull && docker compose --project-directory '$REMOTE_DIR' --file '$REMOTE_DIR/compose.yaml' up -d --remove-orphans"

--- a/deploy/healthcheck.sh
+++ b/deploy/healthcheck.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+HEALTHCHECK_URL="${HEALTHCHECK_URL:?Set HEALTHCHECK_URL to the backend health endpoint}"
+curl --fail --silent --show-error --max-time "${HEALTHCHECK_TIMEOUT_SECONDS:-15}" "$HEALTHCHECK_URL"
+printf '\nhealth check passed: %s\n' "$HEALTHCHECK_URL"

--- a/deploy/migrate.sh
+++ b/deploy/migrate.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REMOTE_HOST="${REMOTE_HOST:?Set REMOTE_HOST at invocation time; do not commit an address}"
+REMOTE_USER="${REMOTE_USER:-eddies}"
+REMOTE_DIR="${REMOTE_DIR:-/opt/eddies-wallet/deploy}"
+MIGRATION_COMMAND="${MIGRATION_COMMAND:?Set MIGRATION_COMMAND to the reviewed backend migration command}"
+
+ssh -o BatchMode=yes "$REMOTE_USER@$REMOTE_HOST" \
+  "docker compose --project-directory '$REMOTE_DIR' --file '$REMOTE_DIR/compose.yaml' run --rm --no-deps backend sh -lc '$MIGRATION_COMMAND'"

--- a/deploy/nightly-encrypted-export.sh
+++ b/deploy/nightly-encrypted-export.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Export the private database, encrypt it with age, and upload it to an
+# independent HTTPS destination. This script intentionally refuses to create a
+# same-disk fallback that could be mistaken for off-site recovery.
+set -Eeuo pipefail
+
+log() { printf 'eddies-wallet-backup: %s\n' "$*" >&2; }
+stop() { log "STOPPED: $*"; exit 78; }
+
+ENV_FILE="${BACKUP_ENV_FILE:-/etc/eddies-wallet/backup.env}"
+[[ -r "$ENV_FILE" ]] || stop "independent encrypted-export destination is not configured; missing $ENV_FILE; no same-disk dump was created"
+set -a
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+set +a
+
+[[ -n "${BACKUP_DESTINATION:-}" ]] || stop "BACKUP_DESTINATION is not configured; no same-disk dump was created"
+[[ -n "${BACKUP_AGE_RECIPIENT:-}" ]] || stop "BACKUP_AGE_RECIPIENT is not configured; no export was created"
+[[ "$BACKUP_DESTINATION" == https://* ]] || stop "BACKUP_DESTINATION must be an independent HTTPS PUT endpoint; no same-disk dump was created"
+case "$BACKUP_DESTINATION" in
+  https://localhost*|https://127.*|https://0.0.0.0*|https://\[::1\]*|https://host.docker.internal*)
+    stop "BACKUP_DESTINATION points at the local host; no same-disk dump was created"
+    ;;
+esac
+
+COMPOSE_DIR="${COMPOSE_DIR:-/opt/eddies-wallet/deploy}"
+COMPOSE_FILE="${COMPOSE_FILE:-$COMPOSE_DIR/compose.yaml}"
+[[ -f "$COMPOSE_FILE" ]] || stop "Compose project is not deployed at $COMPOSE_FILE; no dump was created"
+[[ -f "$COMPOSE_DIR/.env" ]] || stop "host-only Compose environment is missing at $COMPOSE_DIR/.env; no dump was created"
+command -v age >/dev/null 2>&1 || stop "age is not installed; no dump was created"
+command -v curl >/dev/null 2>&1 || stop "curl is not installed; no dump was created"
+
+POSTGRES_DB="${POSTGRES_DB:?POSTGRES_DB is missing from $COMPOSE_DIR/.env}"
+POSTGRES_USER="${POSTGRES_USER:?POSTGRES_USER is missing from $COMPOSE_DIR/.env}"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+DESTINATION="${BACKUP_DESTINATION%/}/eddies-wallet-${STAMP}.sql.gz.age"
+
+log "exporting database to encrypted independent destination"
+docker compose --project-directory "$COMPOSE_DIR" --file "$COMPOSE_FILE" exec -T db \
+  pg_dump --no-owner --no-privileges -U "$POSTGRES_USER" "$POSTGRES_DB" \
+  | gzip -c \
+  | age --encrypt --recipient "$BACKUP_AGE_RECIPIENT" \
+  | curl --fail --silent --show-error --upload-file - "$DESTINATION"
+log "encrypted export uploaded: $DESTINATION"

--- a/deploy/rollback.sh
+++ b/deploy/rollback.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REMOTE_HOST="${REMOTE_HOST:?Set REMOTE_HOST at invocation time; do not commit an address}"
+REMOTE_USER="${REMOTE_USER:-eddies}"
+REMOTE_DIR="${REMOTE_DIR:-/opt/eddies-wallet/deploy}"
+ROLLBACK_BACKEND_IMAGE="${ROLLBACK_BACKEND_IMAGE:?Set ROLLBACK_BACKEND_IMAGE to a previously deployed immutable image}"
+
+ssh -o BatchMode=yes "$REMOTE_USER@$REMOTE_HOST" \
+  "grep -q '^BACKEND_IMAGE=' '$REMOTE_DIR/.env' && sed -i 's#^BACKEND_IMAGE=.*#BACKEND_IMAGE=$ROLLBACK_BACKEND_IMAGE#' '$REMOTE_DIR/.env' || printf '\\nBACKEND_IMAGE=%s\\n' '$ROLLBACK_BACKEND_IMAGE' >> '$REMOTE_DIR/.env'"
+ssh -o BatchMode=yes "$REMOTE_USER@$REMOTE_HOST" \
+  "docker compose --project-directory '$REMOTE_DIR' --file '$REMOTE_DIR/compose.yaml' pull backend && docker compose --project-directory '$REMOTE_DIR' --file '$REMOTE_DIR/compose.yaml' up -d backend proxy"

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,9 @@
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+crash.log
+crash.*.log
+*.tfvars
+*.tfvars.json
+!*.tfvars.example

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hetznercloud/hcloud" {
+  version     = "1.66.1"
+  constraints = "1.66.1"
+  hashes = [
+    "h1:4umCzzfMlXTswvnn46dX0tPNl267O72eIXRkO/+Nfng=",
+    "zh:113070176eb4fb26a3758b3d1031bb904e34a74f7c4f99f90df2301ca4468a51",
+    "zh:1bfc988bdcd7c9422e09c262c736ad265a205684f0402fa4a83e63c0b08e09ea",
+    "zh:37d92b4cf0f344295b0d780aabbc1408f02db31141cd4408276455a458071e54",
+    "zh:386bd1207b3ed284b513294ddad9b9f59047a693c3aa375605f858f9d9758b58",
+    "zh:43d26f0a4f5a64bf0ade1c5a278b40153d4ae8c77508933b9c8bb7f7860dae6d",
+    "zh:6a1fe681a1706be87f0d03b749f1dc69c838d663c6ab08a00ae8d87be2e4425e",
+    "zh:7032556ae2a74b2e1b7d68add9b96158e4f7202ebb8fbd75e0e8a1581719df7b",
+    "zh:893296927373b4afa7ec3639abb1ebab3c1b6cb9cfe427877cfa7bf69a33480d",
+    "zh:8d58b340e21428a59cc27dc4f5a7fcd2035ee1aa9372c3932f7962647532fe0d",
+    "zh:93509170347bf097ca38e288a6e921811bb769bb2dfac3c339eb2032ae8454c1",
+    "zh:9c00443cb5ae2401089a62e223d7d741eedb04f6a73c357b6a7443b6ae71b0be",
+    "zh:9c356be5ce8cb7b1d83d5cf2276823242f106dbd0c43fe992055f0fa11290f95",
+    "zh:f619116583c7e47751e0baefffca216c83f9f42edf99325121b85ee075db78cc",
+  ]
+}

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,54 @@
+# OpenTofu infrastructure
+
+OpenTofu is the source of truth for the one development host. The module
+creates exactly one `eddies-wallet-dev` server in `hel1`, a dedicated firewall,
+provider daily backups, and the tracked host bootstrap as Hetzner user data.
+It attaches only the existing `Kun MacHome` key ID `111428521` and does not
+create keys, volumes, DNS records, certificates, or third-party services.
+
+The provider is pinned exactly in `versions.tf`; commit
+`.terraform.lock.hcl` after `tofu init` so provider checksums are reviewable.
+The local state, plans, plugin directory, tfvars, and crash logs are ignored
+and must never be committed.
+
+## Safe workflow
+
+Set the current operator address in the invoking shell. The value below is an
+example placeholder, not a tracked address:
+
+```sh
+export TF_VAR_ssh_admin_cidr='<current-operator-ip>/32'
+```
+
+Initialize without a Hetzner credential:
+
+```sh
+tofu -chdir=infra init
+```
+
+Plan and apply only through the attended Automic contract. The token is read
+from `HCLOUD_TOKEN` by the provider and is not a command argument:
+
+```sh
+av inject +HCLOUD_TOKEN -- tofu -chdir=infra plan -out=eddies-wallet-dev.tfplan
+av inject +HCLOUD_TOKEN -- tofu -chdir=infra apply eddies-wallet-dev.tfplan
+```
+
+The plan file and local state are ignored. Review the plan before apply and
+confirm it contains only one new server and one new firewall. Do not use the
+existing `umami` or `myfirstmate` resources as a target and do not run apply
+with a different SSH key, location, server type, or backup setting.
+
+After apply, retrieve sensitive addresses from local state/output as needed:
+
+```sh
+tofu -chdir=infra output -raw server_ipv4
+tofu -chdir=infra output -raw server_ipv6
+```
+
+The separate `deploy/` directory contains the Compose boundary, migration,
+deployment, rollback, health check, and encrypted export job shape. The host
+bootstrap installs Docker and Compose from Ubuntu packages and holds those
+runtime packages against unattended version changes. It also enables SSH
+key-only access for the non-root `eddies` user and host-level automatic
+security updates.

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,13 @@
+module "development" {
+  source = "./modules/development"
+
+  name                 = var.server_name
+  location             = var.location
+  server_type          = var.server_type
+  image                = var.image
+  ssh_key_id           = var.ssh_key_id
+  ssh_admin_cidr       = var.ssh_admin_cidr
+  deploy_user          = var.deploy_user
+  enable_daily_backups = var.enable_daily_backups
+  bootstrap_file       = abspath("${path.root}/../deploy/bootstrap.sh")
+}

--- a/infra/modules/development/main.tf
+++ b/infra/modules/development/main.tf
@@ -1,0 +1,79 @@
+data "hcloud_ssh_key" "kun_machome" {
+  id = var.ssh_key_id
+}
+
+resource "hcloud_firewall" "development" {
+  name = "eddies-wallet-dev-firewall"
+
+  # SSH is restricted to the current operator CIDR. HTTP and HTTPS remain
+  # open for the future reverse-proxy boundary. No database ingress rule exists.
+  rule {
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "22"
+    source_ips  = [var.ssh_admin_cidr]
+    description = "SSH from current operator only"
+  }
+
+  rule {
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "80"
+    source_ips  = ["0.0.0.0/0", "::/0"]
+    description = "Future HTTP reverse proxy"
+  }
+
+  rule {
+    direction   = "in"
+    protocol    = "tcp"
+    port        = "443"
+    source_ips  = ["0.0.0.0/0", "::/0"]
+    description = "Future HTTPS reverse proxy"
+  }
+
+  # Keep package updates, image pulls, DNS, and time synchronization working.
+  rule {
+    direction       = "out"
+    protocol        = "tcp"
+    port            = "1-65535"
+    destination_ips = ["0.0.0.0/0", "::/0"]
+    description     = "Outbound TCP"
+  }
+
+  rule {
+    direction       = "out"
+    protocol        = "udp"
+    port            = "1-65535"
+    destination_ips = ["0.0.0.0/0", "::/0"]
+    description     = "Outbound UDP"
+  }
+
+  rule {
+    direction       = "out"
+    protocol        = "icmp"
+    destination_ips = ["0.0.0.0/0", "::/0"]
+    description     = "Outbound ICMP"
+  }
+}
+
+resource "hcloud_server" "development" {
+  name         = var.name
+  server_type  = var.server_type
+  image        = var.image
+  location     = var.location
+  ssh_keys     = [data.hcloud_ssh_key.kun_machome.id]
+  backups      = var.enable_daily_backups
+  firewall_ids = [hcloud_firewall.development.id]
+  user_data    = <<-USERDATA
+    #!/usr/bin/env bash
+    export SSH_ADMIN_CIDR='${var.ssh_admin_cidr}'
+    export DEPLOY_USER='${var.deploy_user}'
+    ${file(var.bootstrap_file)}
+  USERDATA
+
+  labels = {
+    application = "eddies-wallet"
+    environment = "development"
+    managed_by  = "opentofu"
+  }
+}

--- a/infra/modules/development/outputs.tf
+++ b/infra/modules/development/outputs.tf
@@ -1,0 +1,35 @@
+output "server_id" {
+  value = hcloud_server.development.id
+}
+
+output "server_name" {
+  value = hcloud_server.development.name
+}
+
+output "server_ipv4" {
+  value = hcloud_server.development.ipv4_address
+}
+
+output "server_ipv6" {
+  value = hcloud_server.development.ipv6_address
+}
+
+output "firewall_id" {
+  value = hcloud_firewall.development.id
+}
+
+output "attached_ssh_key" {
+  value = {
+    id          = data.hcloud_ssh_key.kun_machome.id
+    name        = data.hcloud_ssh_key.kun_machome.name
+    fingerprint = data.hcloud_ssh_key.kun_machome.fingerprint
+  }
+}
+
+output "backups_enabled" {
+  value = hcloud_server.development.backups
+}
+
+output "host_bootstrap_sha256" {
+  value = filesha256(var.bootstrap_file)
+}

--- a/infra/modules/development/variables.tf
+++ b/infra/modules/development/variables.tf
@@ -1,0 +1,41 @@
+variable "name" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "server_type" {
+  type = string
+}
+
+variable "image" {
+  type = string
+}
+
+variable "ssh_key_id" {
+  type = number
+}
+
+variable "ssh_admin_cidr" {
+  type = string
+}
+
+variable "deploy_user" {
+  type = string
+}
+
+variable "enable_daily_backups" {
+  type = bool
+}
+
+variable "bootstrap_file" {
+  description = "Absolute path to the tracked host bootstrap script."
+  type        = string
+
+  validation {
+    condition     = fileexists(var.bootstrap_file)
+    error_message = "The tracked host bootstrap file must exist before apply."
+  }
+}

--- a/infra/modules/development/versions.tf
+++ b/infra/modules/development/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "= 1.66.1"
+    }
+  }
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,41 @@
+output "server_id" {
+  description = "Hetzner ID of the single development server."
+  value       = module.development.server_id
+}
+
+output "server_name" {
+  description = "Development server name."
+  value       = module.development.server_name
+}
+
+output "server_ipv4" {
+  description = "Development server public IPv4."
+  value       = module.development.server_ipv4
+  sensitive   = true
+}
+
+output "server_ipv6" {
+  description = "Development server public IPv6 prefix."
+  value       = module.development.server_ipv6
+  sensitive   = true
+}
+
+output "firewall_id" {
+  description = "Dedicated provider firewall ID."
+  value       = module.development.firewall_id
+}
+
+output "attached_ssh_key" {
+  description = "The existing SSH key attached to the server."
+  value       = module.development.attached_ssh_key
+}
+
+output "backups_enabled" {
+  description = "Whether Hetzner daily server backups are enabled."
+  value       = module.development.backups_enabled
+}
+
+output "host_bootstrap_sha256" {
+  description = "Hash of the bootstrap asset rendered into server user_data."
+  value       = module.development.host_bootstrap_sha256
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,86 @@
+variable "server_name" {
+  description = "The single dedicated development server name."
+  type        = string
+  default     = "eddies-wallet-dev"
+
+  validation {
+    condition     = var.server_name == "eddies-wallet-dev"
+    error_message = "This foundation intentionally manages only eddies-wallet-dev."
+  }
+}
+
+variable "location" {
+  description = "Hetzner location for the development server."
+  type        = string
+  default     = "hel1"
+
+  validation {
+    condition     = var.location == "hel1"
+    error_message = "The development foundation is intentionally limited to hel1."
+  }
+}
+
+variable "server_type" {
+  description = "Smallest suitable 4 GB / 2 shared CPU development server type."
+  type        = string
+  default     = "cx23"
+
+  validation {
+    condition     = var.server_type == "cx23"
+    error_message = "Use cx23 for this low-cost development foundation."
+  }
+}
+
+variable "image" {
+  description = "Supported Ubuntu LTS image name."
+  type        = string
+  default     = "ubuntu-24.04"
+
+  validation {
+    condition     = var.image == "ubuntu-24.04"
+    error_message = "Use Ubuntu 24.04 LTS for this foundation."
+  }
+}
+
+variable "ssh_key_id" {
+  description = "Existing Kun MacHome Hetzner SSH key ID. No key is created by this configuration."
+  type        = number
+  default     = 111428521
+
+  validation {
+    condition     = var.ssh_key_id == 111428521
+    error_message = "Only the existing Kun MacHome key (ID 111428521) may be attached."
+  }
+}
+
+variable "ssh_admin_cidr" {
+  description = "Current operator IPv4 CIDR allowed to reach SSH, for example 203.0.113.10/32."
+  type        = string
+
+  validation {
+    condition     = can(cidrhost(var.ssh_admin_cidr, 0)) && strcontains(var.ssh_admin_cidr, "/")
+    error_message = "Provide the current operator address as an explicit CIDR."
+  }
+}
+
+variable "deploy_user" {
+  description = "Non-root host user used for Compose deployments."
+  type        = string
+  default     = "eddies"
+
+  validation {
+    condition     = var.deploy_user == "eddies"
+    error_message = "The bootstrap contract expects the eddies deployment user."
+  }
+}
+
+variable "enable_daily_backups" {
+  description = "Enable the provider's daily server backup option."
+  type        = bool
+  default     = true
+
+  validation {
+    condition     = var.enable_daily_backups
+    error_message = "Daily backups are required by the MVP recovery posture."
+  }
+}

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.8.0, < 2.0.0"
+
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "= 1.66.1"
+    }
+  }
+
+  # Local state is intentionally ignored by Git. Set TF_DATA_DIR or use the
+  # default infra/.terraform directory for provider/plugin working data.
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}
+
+# The provider reads HCLOUD_TOKEN from the environment. Never put the token in
+# variables, tfvars, state, plans, or tracked files.
+provider "hcloud" {}


### PR DESCRIPTION
## Summary
- add pinned OpenTofu Hetzner provider configuration and a single development-server module
- provision the dedicated firewall, Ubuntu LTS host bootstrap, SSH hardening, and daily provider backups
- add vendor-neutral Compose, migration, rollback, health-check, and guarded encrypted-export assets

## Validation
- `tofu init` and `tofu validate`
- OpenTofu plan/apply created only the development server and dedicated firewall
- follow-up OpenTofu plan reports no changes
- shellcheck and bash syntax checks
- Compose config check with placeholders
- encrypted export guard test stops when the independent destination is missing

No DNS, certificates, object storage, extra volumes, or production endpoint were configured.