### PR TITLE
feat: add authoritative wallet backend slice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+- Add durable project-specific notes here as they are discovered through real work.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.
+
+- The backend vertical slice lives under `backend/`; use `backend/README.md` for local PostgreSQL, migration, API, and test commands.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.env
+.git
+coverage

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,10 @@
+# Copy to .env for local work. No production secrets belong in this file.
+NODE_ENV=development
+PORT=3000
+DATABASE_URL=postgresql://postgres@localhost:5433/eddys_wallet
+AUTH_MODE=local
+SESSION_TTL_DAYS=30
+# Apple mode requires both values. Keep this in an untracked local env file.
+# AUTH_MODE=apple
+# APPLE_AUDIENCES=com.example.eddys-wallet
+# APPLE_NONCE_REQUIRED=true

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.env
+.env.*
+!.env.example
+coverage/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:22-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY --from=build /app/dist ./dist
+COPY migrations ./migrations
+EXPOSE 3000
+CMD ["sh", "-c", "node dist/src/db/migrate.js && node dist/src/index.js"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,9 +9,10 @@ RUN npm run build
 FROM node:22-alpine
 WORKDIR /app
 ENV NODE_ENV=production
+ENV PORT=8080
 COPY package*.json ./
 RUN npm ci --omit=dev
 COPY --from=build /app/dist ./dist
 COPY migrations ./migrations
-EXPOSE 3000
+EXPOSE 8080
 CMD ["sh", "-c", "node dist/src/db/migrate.js && node dist/src/index.js"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -24,6 +24,8 @@ npm run dev
 
 The Compose database uses PostgreSQL's `trust` mode and contains no useful credentials. It is for a disposable local database only. Do not use that setting for deployment. The Compose API can also be started with `docker compose up --build`.
 
+The production image defaults to `PORT=8080` and exposes `8080`, matching `deploy/compose.yaml` and Caddy's `reverse_proxy backend:8080`. The local Compose service explicitly overrides `PORT=3000` and maps `3000:3000`, so local development remains on port 3000. The production migration command is `node dist/src/db/migrate.js`, matching the compiled image layout and `deploy/.env.example`.
+
 `npm test` runs the unit tests and skips the PostgreSQL integration suite when `DATABASE_URL` is unset. The integration command above is the strongest local check: it runs migrations and exercises the HTTP API, PostgreSQL transactions, database triggers, authorization ownership, and idempotency. Tests create only local-auth identities and need no Apple or production credentials.
 
 ## Configuration and authentication

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,123 @@
+# Eddie's Wallet backend
+
+This directory contains the first authoritative backend vertical slice for Eddie's Wallet. It is a small Node.js/TypeScript API backed by PostgreSQL. The balance is virtual bookkeeping only: US-dollar vocabulary is used for display, but no real money, payment provider, bank, card, or redemption path exists.
+
+## Local setup
+
+Requirements: Node.js 20+, Docker, and Docker Compose.
+
+```sh
+cd backend
+cp .env.example .env
+npm install
+npm run lint
+npm run test:unit
+
+docker compose up -d postgres
+npm run migrate
+DATABASE_URL=postgresql://postgres@localhost:5433/eddys_wallet npm run test:integration
+
+# Run the API outside Docker in local-auth mode:
+set -a; . ./.env; set +a
+npm run dev
+```
+
+The Compose database uses PostgreSQL's `trust` mode and contains no useful credentials. It is for a disposable local database only. Do not use that setting for deployment. The Compose API can also be started with `docker compose up --build`.
+
+`npm test` runs the unit tests and skips the PostgreSQL integration suite when `DATABASE_URL` is unset. The integration command above is the strongest local check: it runs migrations and exercises the HTTP API, PostgreSQL transactions, database triggers, authorization ownership, and idempotency. Tests create only local-auth identities and need no Apple or production credentials.
+
+## Configuration and authentication
+
+Configuration is environment-driven:
+
+- `DATABASE_URL` - PostgreSQL connection string.
+- `PORT` - HTTP port, default `3000`.
+- `NODE_ENV` - `production` rejects local authentication.
+- `AUTH_MODE` - `apple` (default) or `local` for development and tests only.
+- `APPLE_AUDIENCES` - comma-separated Apple client IDs, required in Apple mode.
+- `APPLE_NONCE_REQUIRED` - defaults to `true`; keep nonce checking enabled for the Sign in with Apple flow.
+- `SESSION_TTL_DAYS` - opaque API session lifetime, default `30`.
+
+In Apple mode, `POST /v1/auth/apple` verifies the supplied identity token with Apple's published JWKS at `https://appleid.apple.com/auth/keys`. Verification requires the Apple issuer, configured audience, signature, and token time claims. The request nonce is checked against the token nonce by `jose`; the API requires a nonce by default. The server stores only the Apple subject and optional email, never the identity token.
+
+For local development only:
+
+```sh
+curl -s http://localhost:3000/v1/auth/local \
+  -H 'content-type: application/json' \
+  -d '{"subject":"local-parent"}'
+```
+
+The response contains an opaque bearer session. `/v1/auth/local` returns 404 in Apple mode, and startup fails if `AUTH_MODE=local` is combined with `NODE_ENV=production`. No Apple secret or private key is needed by this service.
+
+## API contract
+
+All protected endpoints require `Authorization: Bearer <session>`. The server derives the parent identity from the session and checks family ownership from the database. There is no client-controlled role flag. The child view is a deliberately read-only response shape, not a child credential or an authorization grant.
+
+All mutating commands require a unique `Idempotency-Key` header. A retry with the same key and the same canonical request returns the original status and body. Reusing a key with a different request returns `409 IDEMPOTENCY_KEY_REUSED`. Failed commands roll back their idempotency record and may be retried.
+
+Money fields are integer `amountCents` values. The service converts them to `bigint` before arithmetic and PostgreSQL stores them as `bigint`; fractional amounts, zero, negative amounts, and values above the safe API limit are rejected. JSON responses use numbers because the service caps values below JavaScript's safe JSON integer range.
+
+### Health and sessions
+
+| Method | Path | Auth | Purpose |
+| --- | --- | --- | --- |
+| GET | `/healthz` | No | Database-backed health check |
+| POST | `/v1/auth/apple` | No | Verify Apple identity token and create parent session |
+| POST | `/v1/auth/local` | No, local mode only | Development-only parent session |
+| GET | `/v1/me` | Yes | Parent identity and setup summary |
+
+Apple request: `{ "identityToken": "...", "nonce": "..." }`.
+
+### Setup and reads
+
+| Method | Path | Idempotency | Purpose |
+| --- | --- | --- | --- |
+| POST | `/v1/family/setup` | Required | Create the one family, Eddie profile, and wallet |
+| PATCH | `/v1/family` | Required | Rename the family |
+| PATCH | `/v1/child/profile` | Required | Update nickname, optional avatar URL, or lesson age-band label |
+| GET | `/v1/family` | No | Parent setup and wallet snapshot |
+| GET | `/v1/wallet` | No | Wallet snapshot with recent activity, rule, and latest loan |
+| GET | `/v1/child-view` | No | Child-safe, read-only wallet snapshot |
+| GET | `/v1/activity?limit=50` | No | Accepted activity, newest first; limit 1-100 |
+| GET | `/v1/activity/:entryId` | No | Accepted activity details |
+| GET | `/v1/loans/:loanId` | No | Loan and its accepted loan/repayment entries |
+
+Every money detail includes the persistent notice: `Virtual practice only. These dollars are pretend, cannot be redeemed, and never move real money.`
+
+### Parent commands
+
+| Method | Path | Body | Purpose |
+| --- | --- | --- | --- |
+| PUT | `/v1/allowance-rule` | `{ amountCents, cadence: "weekly", weekday: 0-6, startDate, endDate? }` | Create or replace the one active weekly rule |
+| GET | `/v1/allowance-rule` | - | Read the rule and next scheduled occurrence |
+| POST | `/v1/allowance-rule/:ruleId/occurrences/:occurrenceId/record` | `{ reason? }` | Parent-confirm and record one due occurrence |
+| POST | `/v1/wallet/deposits` | `{ amountCents, reason? }` | Record a positive deposit |
+| POST | `/v1/wallet/withdrawals` | `{ amountCents, reason? }` | Record a withdrawal if the accepted balance is sufficient |
+| POST | `/v1/loans` | `{ principalCents, purpose?, dueDate? }` | Create one interest-free open loan and credit the wallet |
+| POST | `/v1/loans/:loanId/repayments` | `{ amountCents, reason? }` | Record a partial or full repayment |
+
+Accepted ledger entries cannot be edited or deleted. The only correction shape is a new parent-recorded compensating event. Withdrawals and repayments are checked inside a transaction against a row-locked wallet. Repayment is also checked against a row-locked outstanding principal. Loan creation is limited to one open loan. Allowance replacement cancels only future scheduled occurrences; recorded history remains unchanged.
+
+## Data model and migrations
+
+Migrations are append-only SQL files in `migrations/` and are applied by `npm run migrate` under a PostgreSQL advisory lock. The core tables are:
+
+- `parent_identities` and `sessions` for Apple/local subject identity and opaque sessions.
+- `families`, `children`, and `wallets` for the one-owner, one-child MVP.
+- `ledger_entries` for accepted immutable events with before/after balances and server actor/timestamp fields.
+- `allowance_rules` and `allowance_occurrences` for one weekly parent-confirmed rule.
+- `loans` and `repayments` for one interest-free open loan at a time and its immutable repayment records.
+- `idempotency_records` for replay-safe command responses.
+
+Database triggers reject ledger updates/deletes, verify that a new ledger entry starts at the current wallet balance, and reject direct wallet balance changes unless the service has created the corresponding accepted ledger entry in the same transaction. Application queries never accept client timestamps, actors, or balances.
+
+## Deliberately narrow choices and remaining decisions
+
+This slice does not silently implement unresolved product policy:
+
+- Allowances are weekly only, parent-confirmed, and do not run a background scheduler or catch up missed dates. A scheduled occurrence is distinct from a recorded event.
+- The `lessonAgeBand` is an opaque required label, so product can choose exact bands later without a backend migration.
+- The API has one parent owner and one Eddie profile. There is no child login, Google auth, co-parent membership, PIN protocol, child request flow, interest, multiple wallet, payments, analytics, or administration surface.
+- Offline queueing is an eventual client concern. The API accepts only authoritative commands and never labels an unaccepted command as recorded.
+- Backup scheduling, encrypted export, retention/deletion policy, PIN recovery, iOS support versions, and the final Hetzner operations plan remain launch decisions. This repository does not claim those operational controls are configured.

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: eddys_wallet
+      POSTGRES_USER: postgres
+      POSTGRES_HOST_AUTH_METHOD: trust
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d eddys_wallet"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
+  api:
+    build: .
+    environment:
+      NODE_ENV: development
+      PORT: 3000
+      DATABASE_URL: postgresql://postgres@postgres:5432/eddys_wallet
+      AUTH_MODE: local
+    command: ["sh", "-c", "node dist/src/db/migrate.js && node dist/src/index.js"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "3000:3000"
+
+volumes:
+  postgres-data:

--- a/backend/migrations/001_identity_and_family.sql
+++ b/backend/migrations/001_identity_and_family.sql
@@ -1,0 +1,59 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE parent_identities (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  provider text NOT NULL CHECK (provider IN ('apple', 'local')),
+  subject text NOT NULL,
+  email text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (provider, subject)
+);
+
+CREATE TABLE sessions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  parent_identity_id uuid NOT NULL REFERENCES parent_identities(id) ON DELETE RESTRICT,
+  token_hash text NOT NULL UNIQUE,
+  expires_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  last_seen_at timestamptz NOT NULL DEFAULT now(),
+  revoked_at timestamptz,
+  CHECK (expires_at > created_at)
+);
+
+CREATE INDEX sessions_active_lookup_idx
+  ON sessions (token_hash, expires_at)
+  WHERE revoked_at IS NULL;
+
+CREATE TABLE families (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_identity_id uuid NOT NULL UNIQUE REFERENCES parent_identities(id) ON DELETE RESTRICT,
+  name text NOT NULL CHECK (char_length(name) BETWEEN 1 AND 120),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE children (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  family_id uuid NOT NULL UNIQUE REFERENCES families(id) ON DELETE RESTRICT,
+  nickname text NOT NULL CHECK (char_length(nickname) BETWEEN 1 AND 80),
+  avatar_url text CHECK (avatar_url IS NULL OR char_length(avatar_url) <= 2048),
+  lesson_age_band text NOT NULL CHECK (char_length(lesson_age_band) BETWEEN 1 AND 32),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE FUNCTION set_updated_at() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER parent_identities_set_updated_at
+  BEFORE UPDATE ON parent_identities FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+CREATE TRIGGER families_set_updated_at
+  BEFORE UPDATE ON families FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+CREATE TRIGGER children_set_updated_at
+  BEFORE UPDATE ON children FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/backend/migrations/002_wallet_and_ledger.sql
+++ b/backend/migrations/002_wallet_and_ledger.sql
@@ -1,0 +1,49 @@
+CREATE TABLE wallets (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  child_id uuid NOT NULL UNIQUE REFERENCES children(id) ON DELETE RESTRICT,
+  currency_code char(3) NOT NULL DEFAULT 'USD' CHECK (currency_code = 'USD'),
+  balance_cents bigint NOT NULL DEFAULT 0 CHECK (balance_cents >= 0),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE loans (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  wallet_id uuid NOT NULL REFERENCES wallets(id) ON DELETE RESTRICT,
+  principal_cents bigint NOT NULL CHECK (principal_cents > 0),
+  outstanding_cents bigint NOT NULL CHECK (outstanding_cents >= 0 AND outstanding_cents <= principal_cents),
+  purpose text CHECK (purpose IS NULL OR char_length(purpose) <= 240),
+  due_date date,
+  status text NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'paid')),
+  created_by_identity_id uuid NOT NULL REFERENCES parent_identities(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  paid_at timestamptz,
+  CHECK ((status = 'open' AND outstanding_cents > 0 AND paid_at IS NULL)
+      OR (status = 'paid' AND outstanding_cents = 0 AND paid_at IS NOT NULL))
+);
+
+CREATE TABLE ledger_entries (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  wallet_id uuid NOT NULL REFERENCES wallets(id) ON DELETE RESTRICT,
+  entry_type text NOT NULL CHECK (entry_type IN ('deposit', 'withdrawal', 'allowance', 'loan', 'repayment')),
+  direction text NOT NULL CHECK (direction IN ('credit', 'debit')),
+  amount_cents bigint NOT NULL CHECK (amount_cents > 0),
+  balance_before_cents bigint NOT NULL CHECK (balance_before_cents >= 0),
+  balance_after_cents bigint NOT NULL CHECK (balance_after_cents >= 0),
+  reason text CHECK (reason IS NULL OR char_length(reason) <= 240),
+  loan_id uuid REFERENCES loans(id) ON DELETE RESTRICT,
+  recorded_by_identity_id uuid NOT NULL REFERENCES parent_identities(id) ON DELETE RESTRICT,
+  recorded_at timestamptz NOT NULL DEFAULT now(),
+  CHECK ((direction = 'credit' AND balance_after_cents = balance_before_cents + amount_cents)
+      OR (direction = 'debit' AND balance_after_cents = balance_before_cents - amount_cents)),
+  CHECK ((entry_type IN ('deposit', 'allowance', 'loan') AND direction = 'credit')
+      OR (entry_type IN ('withdrawal', 'repayment') AND direction = 'debit')),
+  CHECK ((entry_type IN ('loan', 'repayment') AND loan_id IS NOT NULL)
+      OR (entry_type IN ('deposit', 'withdrawal', 'allowance') AND loan_id IS NULL))
+);
+
+CREATE INDEX ledger_entries_wallet_recorded_idx
+  ON ledger_entries (wallet_id, recorded_at DESC, id DESC);
+CREATE INDEX loans_wallet_created_idx
+  ON loans (wallet_id, created_at DESC);

--- a/backend/migrations/003_allowance_idempotency_invariants.sql
+++ b/backend/migrations/003_allowance_idempotency_invariants.sql
@@ -1,0 +1,102 @@
+CREATE TABLE allowance_rules (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  wallet_id uuid NOT NULL UNIQUE REFERENCES wallets(id) ON DELETE RESTRICT,
+  amount_cents bigint NOT NULL CHECK (amount_cents > 0),
+  cadence text NOT NULL CHECK (cadence = 'weekly'),
+  weekday smallint NOT NULL CHECK (weekday BETWEEN 0 AND 6),
+  start_date date NOT NULL,
+  end_date date,
+  active boolean NOT NULL DEFAULT true,
+  created_by_identity_id uuid NOT NULL REFERENCES parent_identities(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (end_date IS NULL OR end_date >= start_date)
+);
+
+CREATE TABLE allowance_occurrences (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  rule_id uuid NOT NULL REFERENCES allowance_rules(id) ON DELETE RESTRICT,
+  due_on date NOT NULL,
+  status text NOT NULL DEFAULT 'scheduled' CHECK (status IN ('scheduled', 'recorded', 'cancelled')),
+  accepted_entry_id uuid UNIQUE REFERENCES ledger_entries(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (rule_id, due_on),
+  CHECK ((status = 'recorded' AND accepted_entry_id IS NOT NULL)
+      OR (status IN ('scheduled', 'cancelled') AND accepted_entry_id IS NULL))
+);
+
+CREATE INDEX allowance_occurrences_next_idx
+  ON allowance_occurrences (rule_id, due_on)
+  WHERE status = 'scheduled';
+
+CREATE TABLE idempotency_records (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_identity_id uuid NOT NULL REFERENCES parent_identities(id) ON DELETE RESTRICT,
+  idempotency_key text NOT NULL CHECK (char_length(idempotency_key) BETWEEN 1 AND 128),
+  request_hash text NOT NULL,
+  response_status smallint,
+  response_body jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (actor_identity_id, idempotency_key),
+  CHECK ((response_status IS NULL AND response_body IS NULL)
+      OR (response_status IS NOT NULL AND response_body IS NOT NULL))
+);
+
+CREATE TRIGGER loans_set_updated_at
+  BEFORE UPDATE ON loans FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+CREATE TRIGGER wallets_set_updated_at
+  BEFORE UPDATE ON wallets FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+CREATE TRIGGER allowance_rules_set_updated_at
+  BEFORE UPDATE ON allowance_rules FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+CREATE TRIGGER allowance_occurrences_set_updated_at
+  BEFORE UPDATE ON allowance_occurrences FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+CREATE UNIQUE INDEX one_open_loan_per_wallet_idx
+  ON loans (wallet_id) WHERE status = 'open';
+
+CREATE FUNCTION reject_ledger_mutation() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'accepted ledger entries are immutable' USING ERRCODE = '55000';
+END;
+$$;
+
+CREATE TRIGGER ledger_entries_immutable
+  BEFORE UPDATE OR DELETE ON ledger_entries
+  FOR EACH ROW EXECUTE FUNCTION reject_ledger_mutation();
+
+CREATE FUNCTION validate_ledger_balance() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+  current_balance bigint;
+BEGIN
+  SELECT balance_cents INTO current_balance FROM wallets WHERE id = NEW.wallet_id FOR UPDATE;
+  IF current_balance IS NULL THEN
+    RAISE EXCEPTION 'wallet does not exist' USING ERRCODE = '23503';
+  END IF;
+  IF NEW.balance_before_cents <> current_balance THEN
+    RAISE EXCEPTION 'ledger balance is not the current wallet balance' USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER ledger_entries_validate_balance
+  BEFORE INSERT ON ledger_entries
+  FOR EACH ROW EXECUTE FUNCTION validate_ledger_balance();
+
+CREATE FUNCTION reject_direct_balance_update() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW.balance_cents <> OLD.balance_cents
+     AND current_setting('eddys_wallet.allow_balance_update', true) IS DISTINCT FROM 'on' THEN
+    RAISE EXCEPTION 'wallet balance changes must be accompanied by an accepted ledger entry' USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER wallets_balance_guard
+  BEFORE UPDATE ON wallets
+  FOR EACH ROW EXECUTE FUNCTION reject_direct_balance_update();

--- a/backend/migrations/004_repayments.sql
+++ b/backend/migrations/004_repayments.sql
@@ -1,0 +1,38 @@
+CREATE TABLE repayments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  loan_id uuid NOT NULL REFERENCES loans(id) ON DELETE RESTRICT,
+  ledger_entry_id uuid NOT NULL UNIQUE REFERENCES ledger_entries(id) ON DELETE RESTRICT,
+  amount_cents bigint NOT NULL CHECK (amount_cents > 0),
+  recorded_by_identity_id uuid NOT NULL REFERENCES parent_identities(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX repayments_loan_created_idx ON repayments (loan_id, created_at ASC);
+
+CREATE FUNCTION validate_repayment_entry() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+  entry ledger_entries%ROWTYPE;
+BEGIN
+  SELECT * INTO entry FROM ledger_entries WHERE id = NEW.ledger_entry_id;
+  IF entry.id IS NULL OR entry.entry_type <> 'repayment' OR entry.loan_id <> NEW.loan_id
+     OR entry.amount_cents <> NEW.amount_cents THEN
+    RAISE EXCEPTION 'repayment must reference its matching accepted ledger entry' USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER repayments_validate_entry
+  BEFORE INSERT ON repayments FOR EACH ROW EXECUTE FUNCTION validate_repayment_entry();
+
+CREATE FUNCTION reject_repayment_mutation() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'accepted repayments are immutable' USING ERRCODE = '55000';
+END;
+$$;
+
+CREATE TRIGGER repayments_immutable
+  BEFORE UPDATE OR DELETE ON repayments
+  FOR EACH ROW EXECUTE FUNCTION reject_repayment_mutation();

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,2447 @@
+{
+  "name": "eddys-wallet-backend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "eddys-wallet-backend",
+      "version": "0.1.0",
+      "dependencies": {
+        "fastify": "^5.4.0",
+        "jose": "^6.0.10",
+        "pg": "^8.13.1",
+        "zod": "^3.24.2"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.7",
+        "@types/pg": "^8.11.10",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.3",
+        "vitest": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.5.tgz",
+      "integrity": "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0"
+      }
+    },
+    "node_modules/@fastify/error": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+      "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.1.0.tgz",
+      "integrity": "sha512-PxcYtKLbQ8Z+yApiqjK8FwxIwvEj38k2OiLc17u8dkJSlmfi2wHHPaSnaoqBPQqtvF8YVsDgDpP2snDCfFrpfw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stringify": "^7.0.0"
+      }
+    },
+    "node_modules/@fastify/forwarded": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.1.tgz",
+      "integrity": "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/merge-json-schemas": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
+      "integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/proxy-addr": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.1.0.tgz",
+      "integrity": "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/forwarded": "^3.0.0",
+        "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+      "license": "MIT"
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/avvio": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.3.0.tgz",
+      "integrity": "sha512-g2tQ7LE7oOSqDfwEm3M+ZCMTJc7KiZCdJ4UwyZJb5ckTKyYu50OYmvv0mCFXPuYXoM4zkSt8zM9XQ9KCvxA74A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "fastq": "^1.17.1"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stringify": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-7.0.1.tgz",
+      "integrity": "sha512-eRSayARSbbwlBjpP4vnTTIRD5QPcIrmihPxDeN1DtKnHPg66UuJLx+8hlK1kaFdjvzyQ/dzALoi4vwAQ+T+iZA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^4.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/fast-uri": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
+      "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastify": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.10.0.tgz",
+      "integrity": "sha512-A9L0ziuWGQHgEEVgF3davQ9vbD93IuX+lo2IsxapQmu5b/Y/ynn9m9K5JHt9dvyJXOFc5iN0Zk5GHEOqnzhWjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^4.0.5",
+        "@fastify/error": "^4.0.0",
+        "@fastify/fast-json-stringify-compiler": "^5.0.0",
+        "@fastify/proxy-addr": "^5.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^9.0.0",
+        "fast-json-stringify": "^7.0.0",
+        "find-my-way": "^9.6.0",
+        "light-my-request": "^6.0.0",
+        "pino": "^9.14.0 || ^10.1.0",
+        "process-warning": "^5.0.0",
+        "rfdc": "^1.3.1",
+        "secure-json-parse": "^4.0.0",
+        "semver": "^7.6.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/find-my-way": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
+      "integrity": "sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-ref-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
+      "integrity": "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/light-my-request": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
+      "integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "process-warning": "^4.0.0",
+        "set-cookie-parser": "^2.6.0"
+      }
+    },
+    "node_modules/light-my-request/node_modules/process-warning": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.4.tgz",
+      "integrity": "sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "eddys-wallet-backend",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Authoritative API for Eddie's Wallet's virtual family ledger",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/src/index.js",
+    "migrate": "tsx src/db/migrate.ts",
+    "test": "vitest run",
+    "test:unit": "vitest run tests/money.test.ts tests/config.test.ts",
+    "test:integration": "vitest run tests/api.integration.test.ts",
+    "lint": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "fastify": "^5.4.0",
+    "jose": "^6.0.10",
+    "pg": "^8.13.1",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.7",
+    "@types/pg": "^8.11.10",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.5"
+  }
+}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,238 @@
+import Fastify, { type FastifyInstance, type FastifyRequest } from 'fastify';
+import { z, ZodError } from 'zod';
+import type { Config } from './config.js';
+import { Database } from './db/client.js';
+import { requestHash } from './domain/canonical.js';
+import { AppError, asAppError } from './errors.js';
+import { AppleIdentityProvider, type IdentityProvider } from './auth/provider.js';
+import { bearerToken, SessionService, type AuthContext } from './auth/sessions.js';
+import { WalletService } from './services/wallet.js';
+
+const authAppleSchema = z.object({
+  identityToken: z.string().min(1).max(16_384),
+  nonce: z.string().min(1).max(512).optional(),
+});
+const localAuthSchema = z.object({ subject: z.string().min(1).max(256), email: z.string().email().optional() });
+const setupSchema = z.object({
+  familyName: z.string().max(120).optional(),
+  nickname: z.string().min(1).max(80),
+  avatarUrl: z.string().url().max(2048).nullable().optional(),
+  lessonAgeBand: z.string().min(1).max(32),
+});
+const profileSchema = z.object({
+  nickname: z.string().min(1).max(80).optional(),
+  avatarUrl: z.string().url().max(2048).nullable().optional(),
+  lessonAgeBand: z.string().min(1).max(32).optional(),
+});
+const familySchema = z.object({ name: z.string().min(1).max(120) });
+const moneySchema = z.object({
+  amountCents: z.union([z.number().int().positive(), z.string().regex(/^\d+$/)]),
+  reason: z.string().max(240).nullable().optional(),
+});
+const loanSchema = z.object({
+  principalCents: z.union([z.number().int().positive(), z.string().regex(/^\d+$/)]),
+  purpose: z.string().max(240).nullable().optional(),
+  dueDate: z.string().optional().nullable(),
+});
+const allowanceSchema = z.object({
+  amountCents: z.union([z.number().int().positive(), z.string().regex(/^\d+$/)]),
+  cadence: z.literal('weekly'),
+  weekday: z.number().int().min(0).max(6),
+  startDate: z.string(),
+  endDate: z.string().nullable().optional(),
+});
+const reasonSchema = z.object({ reason: z.string().max(240).nullable().optional() });
+
+export interface AppDependencies {
+  db: Database;
+  config: Config;
+  identityProvider?: IdentityProvider;
+}
+
+function parse<T>(schema: z.ZodType<T>, value: unknown): T {
+  return schema.parse(value ?? {});
+}
+
+function idempotencyKey(request: FastifyRequest): string {
+  const header = request.headers['idempotency-key'];
+  const key = Array.isArray(header) ? header[0] : header;
+  if (!key || key.length > 128) {
+    throw new AppError(400, 'IDEMPOTENCY_KEY_REQUIRED', 'Mutating commands require an Idempotency-Key header.');
+  }
+  return key;
+}
+
+function queryLimit(request: FastifyRequest): number {
+  const raw = (request.query as { limit?: string } | undefined)?.limit;
+  if (raw === undefined) return 50;
+  const limit = Number(raw);
+  if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+    throw new AppError(400, 'VALIDATION_ERROR', 'limit must be an integer from 1 to 100.');
+  }
+  return limit;
+}
+
+async function requireAuth(request: FastifyRequest, sessions: SessionService): Promise<AuthContext> {
+  return sessions.authenticate(bearerToken(request.headers.authorization));
+}
+
+function sendCommand<T>(reply: { code: (statusCode: number) => { send: (body: T) => unknown } }, response: { statusCode: number; body: T }) {
+  return reply.code(response.statusCode).send(response.body);
+}
+
+export function createApp(dependencies: AppDependencies): FastifyInstance {
+  const { db, config } = dependencies;
+  const app = Fastify({ logger: false });
+  const sessions = new SessionService(db, config.sessionTtlDays);
+  const wallet = new WalletService(db);
+  const identityProvider = dependencies.identityProvider
+    ?? (config.authMode === 'apple' ? new AppleIdentityProvider(config.appleAudiences, config.appleNonceRequired) : undefined);
+
+  app.get('/healthz', async (_request, reply) => {
+    const healthy = await db.health();
+    return reply.code(healthy ? 200 : 503).send({ status: healthy ? 'ok' : 'degraded', database: healthy ? 'ok' : 'unavailable' });
+  });
+
+  app.post('/v1/auth/apple', async (request, reply) => {
+    if (config.authMode !== 'apple' || !identityProvider) {
+      throw new AppError(404, 'NOT_FOUND', 'The requested authentication method is not enabled.');
+    }
+    const body = parse(authAppleSchema, request.body);
+    const identity = await identityProvider.verifyIdentityToken(body.identityToken, body.nonce);
+    const session = await sessions.createSession(identity);
+    return reply.code(201).send({ token: session.token, expiresAt: session.expiresAt, parent: session.auth });
+  });
+
+  app.post('/v1/auth/local', async (request, reply) => {
+    if (config.authMode !== 'local') {
+      throw new AppError(404, 'NOT_FOUND', 'The requested authentication method is not enabled.');
+    }
+    const body = parse(localAuthSchema, request.body);
+    const session = await sessions.createSession({ provider: 'local', subject: body.subject, email: body.email });
+    return reply.code(201).send({ token: session.token, expiresAt: session.expiresAt, parent: session.auth, developmentOnly: true });
+  });
+
+  app.get('/v1/me', async (request) => {
+    const auth = await requireAuth(request, sessions);
+    return sessions.getMe(auth);
+  });
+
+  app.get('/v1/family', async (request) => {
+    const auth = await requireAuth(request, sessions);
+    return wallet.family(auth.identityId);
+  });
+
+  app.post('/v1/family/setup', async (request, reply) => {
+    const auth = await requireAuth(request, sessions);
+    const body = parse(setupSchema, request.body);
+    const key = idempotencyKey(request);
+    return sendCommand(reply, await wallet.setup(auth.identityId, body, key, requestHash(request.url, body)));
+  });
+
+  app.patch('/v1/family', async (request, reply) => {
+    const auth = await requireAuth(request, sessions);
+    const body = parse(familySchema, request.body);
+    const key = idempotencyKey(request);
+    return sendCommand(reply, await wallet.updateFamily(auth.identityId, body, key, requestHash(request.url, body)));
+  });
+
+  app.patch('/v1/child/profile', async (request, reply) => {
+    const auth = await requireAuth(request, sessions);
+    const body = parse(profileSchema, request.body);
+    const key = idempotencyKey(request);
+    return sendCommand(reply, await wallet.updateProfile(auth.identityId, body, key, requestHash(request.url, body)));
+  });
+
+  app.get('/v1/wallet', async (request) => {
+    const auth = await requireAuth(request, sessions);
+    return wallet.family(auth.identityId);
+  });
+
+  app.get('/v1/child-view', async (request) => {
+    const auth = await requireAuth(request, sessions);
+    return wallet.childView(auth.identityId);
+  });
+
+  app.get('/v1/activity', async (request) => {
+    const auth = await requireAuth(request, sessions);
+    return wallet.activity(auth.identityId, queryLimit(request));
+  });
+
+  app.get('/v1/activity/:entryId', async (request) => {
+    const auth = await requireAuth(request, sessions);
+    const params = request.params as { entryId: string };
+    return wallet.activityDetail(auth.identityId, params.entryId);
+  });
+
+  app.get('/v1/loans/:loanId', async (request) => {
+    const auth = await requireAuth(request, sessions);
+    const params = request.params as { loanId: string };
+    return wallet.loanDetail(auth.identityId, params.loanId);
+  });
+
+  app.get('/v1/allowance-rule', async (request) => {
+    const auth = await requireAuth(request, sessions);
+    const current = await wallet.family(auth.identityId);
+    return { allowanceRule: current.allowanceRule };
+  });
+
+  app.put('/v1/allowance-rule', async (request, reply) => {
+    const auth = await requireAuth(request, sessions);
+    const body = parse(allowanceSchema, request.body);
+    const key = idempotencyKey(request);
+    return sendCommand(reply, await wallet.setAllowance(auth.identityId, body, key, requestHash(request.url, body)));
+  });
+
+  app.post('/v1/allowance-rule/:ruleId/occurrences/:occurrenceId/record', async (request, reply) => {
+    const auth = await requireAuth(request, sessions);
+    const body = parse(reasonSchema, request.body);
+    const params = request.params as { ruleId: string; occurrenceId: string };
+    const key = idempotencyKey(request);
+    return sendCommand(reply, await wallet.recordAllowance(auth.identityId, params.ruleId, params.occurrenceId, body, key, requestHash(request.url, body)));
+  });
+
+  app.post('/v1/wallet/deposits', async (request, reply) => {
+    const auth = await requireAuth(request, sessions);
+    const body = parse(moneySchema, request.body);
+    const key = idempotencyKey(request);
+    return sendCommand(reply, await wallet.deposit(auth.identityId, body, key, requestHash(request.url, body)));
+  });
+
+  app.post('/v1/wallet/withdrawals', async (request, reply) => {
+    const auth = await requireAuth(request, sessions);
+    const body = parse(moneySchema, request.body);
+    const key = idempotencyKey(request);
+    return sendCommand(reply, await wallet.withdrawal(auth.identityId, body, key, requestHash(request.url, body)));
+  });
+
+  app.post('/v1/loans', async (request, reply) => {
+    const auth = await requireAuth(request, sessions);
+    const body = parse(loanSchema, request.body);
+    const key = idempotencyKey(request);
+    return sendCommand(reply, await wallet.createLoan(auth.identityId, body, key, requestHash(request.url, body)));
+  });
+
+  app.post('/v1/loans/:loanId/repayments', async (request, reply) => {
+    const auth = await requireAuth(request, sessions);
+    const body = parse(moneySchema, request.body);
+    const params = request.params as { loanId: string };
+    const key = idempotencyKey(request);
+    return sendCommand(reply, await wallet.repayLoan(auth.identityId, params.loanId, body, key, requestHash(request.url, body)));
+  });
+
+  app.setNotFoundHandler((_request, reply) => reply.code(404).send({ error: { code: 'NOT_FOUND', message: 'The requested endpoint was not found.' } }));
+  app.setErrorHandler((error, request, reply) => {
+    if (error instanceof ZodError) {
+      return reply.code(400).send({ error: { code: 'VALIDATION_ERROR', message: 'The request body is invalid.', details: error.flatten() } });
+    }
+    const appError = asAppError(error);
+    if (appError.statusCode >= 500) {
+      request.log.error({ err: error });
+    }
+    return reply.code(appError.statusCode).send({
+      error: { code: appError.code, message: appError.message, ...(appError.details ? { details: appError.details } : {}) },
+    });
+  });
+
+  return app;
+}

--- a/backend/src/auth/provider.ts
+++ b/backend/src/auth/provider.ts
@@ -1,0 +1,47 @@
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { AppError } from '../errors.js';
+
+export interface VerifiedIdentity {
+  provider: 'apple' | 'local';
+  subject: string;
+  email?: string;
+}
+
+export interface IdentityProvider {
+  verifyIdentityToken(token: string, nonce?: string): Promise<VerifiedIdentity>;
+}
+
+export class AppleIdentityProvider implements IdentityProvider {
+  private readonly jwks = createRemoteJWKSet(new URL('https://appleid.apple.com/auth/keys'));
+
+  constructor(
+    private readonly audiences: string[],
+    private readonly nonceRequired: boolean,
+  ) {}
+
+  async verifyIdentityToken(token: string, nonce?: string): Promise<VerifiedIdentity> {
+    if (!token || token.length > 16_384) {
+      throw new AppError(401, 'INVALID_IDENTITY_TOKEN', 'The Apple identity token is invalid.');
+    }
+    if (this.nonceRequired && !nonce) {
+      throw new AppError(401, 'INVALID_IDENTITY_TOKEN', 'A nonce is required for Apple Sign In.');
+    }
+    try {
+      const { payload } = await jwtVerify(token, this.jwks, {
+        issuer: 'https://appleid.apple.com',
+        audience: this.audiences,
+        ...(nonce ? { nonce } : {}),
+      });
+      if (typeof payload.sub !== 'string' || payload.sub.length === 0) {
+        throw new Error('Apple token did not contain a subject.');
+      }
+      return {
+        provider: 'apple',
+        subject: payload.sub,
+        ...(typeof payload.email === 'string' ? { email: payload.email } : {}),
+      };
+    } catch {
+      throw new AppError(401, 'INVALID_IDENTITY_TOKEN', 'The Apple identity token could not be verified.');
+    }
+  }
+}

--- a/backend/src/auth/sessions.ts
+++ b/backend/src/auth/sessions.ts
@@ -1,0 +1,123 @@
+import { createHash, randomBytes } from 'node:crypto';
+import type { Database } from '../db/client.js';
+import { AppError } from '../errors.js';
+import type { VerifiedIdentity } from './provider.js';
+
+export interface AuthContext {
+  identityId: string;
+  provider: 'apple' | 'local';
+  subject: string;
+  email: string | null;
+}
+
+function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+export class SessionService {
+  constructor(
+    private readonly db: Database,
+    private readonly sessionTtlDays: number,
+  ) {}
+
+  async createSession(identity: VerifiedIdentity): Promise<{ token: string; expiresAt: string; auth: AuthContext }> {
+    const token = randomBytes(32).toString('base64url');
+    const expiresAt = new Date(Date.now() + this.sessionTtlDays * 24 * 60 * 60 * 1000);
+    const result = await this.db.query<{
+      id: string;
+      provider: 'apple' | 'local';
+      subject: string;
+      email: string | null;
+    }>(
+      `
+        INSERT INTO parent_identities (provider, subject, email)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (provider, subject) DO UPDATE
+          SET email = COALESCE(EXCLUDED.email, parent_identities.email)
+        RETURNING id, provider, subject, email
+      `,
+      [identity.provider, identity.subject, identity.email ?? null],
+    );
+    const row = result.rows[0];
+    if (!row) throw new Error('Identity insert did not return an identity.');
+    await this.db.query(
+      `INSERT INTO sessions (parent_identity_id, token_hash, expires_at) VALUES ($1, $2, $3)`,
+      [row.id, hashToken(token), expiresAt],
+    );
+    return {
+      token,
+      expiresAt: expiresAt.toISOString(),
+      auth: { identityId: row.id, provider: row.provider, subject: row.subject, email: row.email },
+    };
+  }
+
+  async authenticate(token: string): Promise<AuthContext> {
+    const result = await this.db.query<{
+      identity_id: string;
+      provider: 'apple' | 'local';
+      subject: string;
+      email: string | null;
+    }>(
+      `
+        SELECT i.id AS identity_id, i.provider, i.subject, i.email
+        FROM sessions s
+        JOIN parent_identities i ON i.id = s.parent_identity_id
+        WHERE s.token_hash = $1
+          AND s.revoked_at IS NULL
+          AND s.expires_at > now()
+      `,
+      [hashToken(token)],
+    );
+    const row = result.rows[0];
+    if (!row) throw new AppError(401, 'UNAUTHENTICATED', 'A valid parent session is required.');
+    await this.db.query('UPDATE sessions SET last_seen_at = now() WHERE token_hash = $1', [hashToken(token)]);
+    return {
+      identityId: row.identity_id,
+      provider: row.provider,
+      subject: row.subject,
+      email: row.email,
+    };
+  }
+
+  async getMe(auth: AuthContext): Promise<Record<string, unknown>> {
+    const family = await this.db.query<{
+      id: string;
+      name: string;
+      child_id: string;
+      nickname: string;
+      avatar_url: string | null;
+      lesson_age_band: string;
+    }>(
+      `
+        SELECT f.id, f.name, c.id AS child_id, c.nickname, c.avatar_url, c.lesson_age_band
+        FROM families f
+        JOIN children c ON c.family_id = f.id
+        WHERE f.owner_identity_id = $1
+      `,
+      [auth.identityId],
+    );
+    const row = family.rows[0];
+    return {
+      parent: { provider: auth.provider, subject: auth.subject, email: auth.email },
+      family: row
+        ? {
+            id: row.id,
+            name: row.name,
+            child: {
+              id: row.child_id,
+              nickname: row.nickname,
+              avatarUrl: row.avatar_url,
+              lessonAgeBand: row.lesson_age_band,
+            },
+          }
+        : null,
+    };
+  }
+}
+
+export function bearerToken(header: string | undefined): string {
+  if (!header || !/^Bearer\s+[^\s]+$/i.test(header)) {
+    throw new AppError(401, 'UNAUTHENTICATED', 'A bearer parent session is required.');
+  }
+  return header.replace(/^Bearer\s+/i, '');
+}

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,0 +1,50 @@
+import { AppError } from './errors.js';
+
+export type AuthMode = 'apple' | 'local';
+
+export interface Config {
+  nodeEnv: string;
+  port: number;
+  databaseUrl: string;
+  authMode: AuthMode;
+  appleAudiences: string[];
+  appleNonceRequired: boolean;
+  sessionTtlDays: number;
+}
+
+function positiveInt(value: string | undefined, fallback: number, name: string): number {
+  const parsed = value === undefined ? fallback : Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new AppError(500, 'INVALID_CONFIGURATION', `${name} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
+  const nodeEnv = env.NODE_ENV ?? 'development';
+  const authMode = (env.AUTH_MODE ?? 'apple') as AuthMode;
+  if (authMode !== 'apple' && authMode !== 'local') {
+    throw new AppError(500, 'INVALID_CONFIGURATION', 'AUTH_MODE must be apple or local.');
+  }
+  if (authMode === 'local' && nodeEnv === 'production') {
+    throw new AppError(500, 'INVALID_CONFIGURATION', 'Local authentication cannot be enabled in production.');
+  }
+
+  const appleAudiences = (env.APPLE_AUDIENCES ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (authMode === 'apple' && appleAudiences.length === 0) {
+    throw new AppError(500, 'INVALID_CONFIGURATION', 'APPLE_AUDIENCES is required when AUTH_MODE=apple.');
+  }
+
+  return {
+    nodeEnv,
+    port: positiveInt(env.PORT, 3000, 'PORT'),
+    databaseUrl: env.DATABASE_URL ?? 'postgresql://postgres@localhost:5433/eddys_wallet',
+    authMode,
+    appleAudiences,
+    appleNonceRequired: (env.APPLE_NONCE_REQUIRED ?? 'true').toLowerCase() !== 'false',
+    sessionTtlDays: positiveInt(env.SESSION_TTL_DAYS, 30, 'SESSION_TTL_DAYS'),
+  };
+}

--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -1,0 +1,53 @@
+import pg from 'pg';
+import type { QueryResult, QueryResultRow } from 'pg';
+
+const { Pool } = pg;
+// Keep PostgreSQL DATE values as YYYY-MM-DD strings instead of timezone-sensitive JS Dates.
+pg.types.setTypeParser(1082, (value) => value);
+
+export interface SqlClient {
+  query<T extends QueryResultRow = QueryResultRow>(
+    text: string,
+    values?: unknown[],
+  ): Promise<QueryResult<T>>;
+}
+
+export class Database implements SqlClient {
+  readonly pool: pg.Pool;
+
+  constructor(databaseUrl: string) {
+    this.pool = new Pool({ connectionString: databaseUrl, max: 10 });
+  }
+
+  query<T extends QueryResultRow = QueryResultRow>(text: string, values?: unknown[]) {
+    return this.pool.query<T>(text, values);
+  }
+
+  async transaction<T>(work: (client: pg.PoolClient) => Promise<T>): Promise<T> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      const result = await work(client);
+      await client.query('COMMIT');
+      return result;
+    } catch (error) {
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+
+  async health(): Promise<boolean> {
+    try {
+      await this.pool.query('SELECT 1');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.pool.end();
+  }
+}

--- a/backend/src/db/migrate.ts
+++ b/backend/src/db/migrate.ts
@@ -1,0 +1,71 @@
+import { createHash } from 'node:crypto';
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import pg from 'pg';
+
+const MIGRATIONS_DIR = process.env.MIGRATIONS_DIR ?? join(process.cwd(), 'migrations');
+
+export async function runMigrations(databaseUrl: string): Promise<void> {
+  const pool = new pg.Pool({ connectionString: databaseUrl, max: 1 });
+  const client = await pool.connect();
+  try {
+    await client.query('SELECT pg_advisory_lock(729381246)');
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS schema_migrations (
+        version bigint PRIMARY KEY,
+        name text NOT NULL,
+        checksum text NOT NULL,
+        applied_at timestamptz NOT NULL DEFAULT now()
+      )
+    `);
+
+    const names = (await readdir(MIGRATIONS_DIR))
+      .filter((name) => /^\d+_[a-z0-9_]+\.sql$/.test(name))
+      .sort();
+    for (const name of names) {
+      const versionText = name.split('_', 1)[0];
+      const version = Number(versionText);
+      const sql = await readFile(join(MIGRATIONS_DIR, name), 'utf8');
+      const checksum = createHash('sha256').update(sql).digest('hex');
+      const existing = await client.query<{ checksum: string }>(
+        'SELECT checksum FROM schema_migrations WHERE version = $1',
+        [version],
+      );
+      if (existing.rows.length > 0) {
+        if (existing.rows[0]?.checksum !== checksum) {
+          throw new Error(`Migration ${name} was changed after it was applied.`);
+        }
+        continue;
+      }
+      await client.query('BEGIN');
+      try {
+        await client.query(sql);
+        await client.query(
+          'INSERT INTO schema_migrations (version, name, checksum) VALUES ($1, $2, $3)',
+          [version, name, checksum],
+        );
+        await client.query('COMMIT');
+      } catch (error) {
+        await client.query('ROLLBACK');
+        throw error;
+      }
+    }
+    await client.query('SELECT pg_advisory_unlock(729381246)');
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const databaseUrl = process.env.DATABASE_URL ?? 'postgresql://postgres@localhost:5433/eddys_wallet';
+  runMigrations(databaseUrl)
+    .then(() => {
+      console.log('Database migrations are up to date.');
+    })
+    .catch((error: unknown) => {
+      console.error(error);
+      process.exitCode = 1;
+    });
+}

--- a/backend/src/domain/canonical.ts
+++ b/backend/src/domain/canonical.ts
@@ -1,0 +1,21 @@
+import { createHash } from 'node:crypto';
+
+function sortValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortValue);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nested]) => [key, sortValue(nested)]),
+    );
+  }
+  return value;
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortValue(value));
+}
+
+export function requestHash(path: string, body: unknown): string {
+  return createHash('sha256').update(canonicalJson({ path, body })).digest('hex');
+}

--- a/backend/src/domain/dates.ts
+++ b/backend/src/domain/dates.ts
@@ -1,0 +1,29 @@
+import { validationError } from '../errors.js';
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export function parseDateOnly(value: unknown, fieldName: string): string {
+  if (typeof value !== 'string' || !DATE_PATTERN.test(value)) {
+    throw validationError(`${fieldName} must use YYYY-MM-DD.`);
+  }
+  const date = new Date(`${value}T00:00:00.000Z`);
+  if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 10) !== value) {
+    throw validationError(`${fieldName} must be a valid calendar date.`);
+  }
+  return value;
+}
+
+export function weekdayOfDate(dateOnly: string): number {
+  return new Date(`${dateOnly}T00:00:00.000Z`).getUTCDay();
+}
+
+export function addDays(dateOnly: string, days: number): string {
+  const date = new Date(`${dateOnly}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+export function nextWeeklyDate(startDate: string, weekday: number): string {
+  const delta = (weekday - weekdayOfDate(startDate) + 7) % 7;
+  return addDays(startDate, delta);
+}

--- a/backend/src/domain/money.ts
+++ b/backend/src/domain/money.ts
@@ -1,0 +1,39 @@
+import { AppError, validationError } from '../errors.js';
+
+export const MAX_AMOUNT_CENTS = 9_000_000_000_000n;
+
+export function parseAmountCents(value: unknown, fieldName = 'amountCents'): bigint {
+  let parsed: bigint;
+  if (typeof value === 'bigint') {
+    parsed = value;
+  } else if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value)) {
+      throw validationError(`${fieldName} must be an integer number of cents.`);
+    }
+    parsed = BigInt(value);
+  } else if (typeof value === 'string' && /^[0-9]+$/.test(value)) {
+    parsed = BigInt(value);
+  } else {
+    throw validationError(`${fieldName} must be an integer number of cents.`);
+  }
+  if (parsed <= 0n || parsed > MAX_AMOUNT_CENTS) {
+    throw validationError(`${fieldName} must be between 1 and ${MAX_AMOUNT_CENTS.toString()} cents.`);
+  }
+  return parsed;
+}
+
+export function toJsonCents(value: bigint | string | number): number {
+  const cents = typeof value === 'bigint' ? value : BigInt(value);
+  if (cents > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error('A money value exceeded the JSON safe integer range.');
+  }
+  return Number(cents);
+}
+
+export function subtractCents(balance: bigint, amount: bigint, label: string): bigint {
+  const result = balance - amount;
+  if (result < 0n) {
+    throw new AppError(409, 'INSUFFICIENT_BALANCE', `${label} cannot exceed the available balance.`);
+  }
+  return result;
+}

--- a/backend/src/errors.ts
+++ b/backend/src/errors.ts
@@ -1,0 +1,22 @@
+export type ErrorDetails = Record<string, unknown>;
+
+export class AppError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    public readonly code: string,
+    message: string,
+    public readonly details?: ErrorDetails,
+  ) {
+    super(message);
+    this.name = 'AppError';
+  }
+}
+
+export function validationError(message: string, details?: ErrorDetails): AppError {
+  return new AppError(400, 'VALIDATION_ERROR', message, details);
+}
+
+export function asAppError(error: unknown): AppError {
+  if (error instanceof AppError) return error;
+  return new AppError(500, 'INTERNAL_ERROR', 'An unexpected error occurred.');
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,0 +1,23 @@
+import { createApp } from './app.js';
+import { loadConfig } from './config.js';
+import { Database } from './db/client.js';
+
+const config = loadConfig();
+const db = new Database(config.databaseUrl);
+const app = createApp({ db, config });
+
+const shutdown = async (signal: string) => {
+  app.log.info(`Received ${signal}; shutting down.`);
+  await app.close();
+  await db.close();
+  process.exit(0);
+};
+
+process.once('SIGTERM', () => void shutdown('SIGTERM'));
+process.once('SIGINT', () => void shutdown('SIGINT'));
+
+app.listen({ port: config.port, host: '0.0.0.0' }).catch(async (error) => {
+  app.log.error(error);
+  await db.close();
+  process.exit(1);
+});

--- a/backend/src/services/idempotency.ts
+++ b/backend/src/services/idempotency.ts
@@ -1,0 +1,62 @@
+import type { Database, SqlClient } from '../db/client.js';
+import { AppError } from '../errors.js';
+
+export interface CommandResponse<T> {
+  statusCode: number;
+  body: T;
+}
+
+export async function runIdempotent<T>(
+  db: Database,
+  actorIdentityId: string,
+  idempotencyKey: string,
+  requestHash: string,
+  work: (client: SqlClient) => Promise<CommandResponse<T>>,
+): Promise<CommandResponse<T>> {
+  return db.transaction(async (client) => {
+    const inserted = await client.query<{ id: string }>(
+      `
+        INSERT INTO idempotency_records (actor_identity_id, idempotency_key, request_hash)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (actor_identity_id, idempotency_key) DO NOTHING
+        RETURNING id
+      `,
+      [actorIdentityId, idempotencyKey, requestHash],
+    );
+
+    if (inserted.rows.length === 0) {
+      const existing = await client.query<{
+        request_hash: string;
+        response_status: number | null;
+        response_body: T | null;
+      }>(
+        `
+          SELECT request_hash, response_status, response_body
+          FROM idempotency_records
+          WHERE actor_identity_id = $1 AND idempotency_key = $2
+          FOR UPDATE
+        `,
+        [actorIdentityId, idempotencyKey],
+      );
+      const row = existing.rows[0];
+      if (!row || row.request_hash !== requestHash) {
+        throw new AppError(409, 'IDEMPOTENCY_KEY_REUSED', 'The idempotency key was used with a different command.');
+      }
+      if (row.response_status === null || row.response_body === null) {
+        throw new AppError(409, 'COMMAND_IN_PROGRESS', 'The command is still being processed. Retry it.');
+      }
+      return { statusCode: row.response_status, body: row.response_body };
+    }
+
+    const response = await work(client);
+    await client.query(
+      `
+        UPDATE idempotency_records
+        SET response_status = $1, response_body = $2
+        WHERE actor_identity_id = $3 AND idempotency_key = $4
+      `,
+      [response.statusCode, JSON.stringify(response.body), actorIdentityId, idempotencyKey],
+    );
+    return response;
+  });
+}

--- a/backend/src/services/wallet.ts
+++ b/backend/src/services/wallet.ts
@@ -1,0 +1,641 @@
+import type { SqlClient, Database } from '../db/client.js';
+import { addDays, nextWeeklyDate, parseDateOnly } from '../domain/dates.js';
+import { MAX_AMOUNT_CENTS, parseAmountCents, subtractCents, toJsonCents } from '../domain/money.js';
+import { AppError, validationError } from '../errors.js';
+import { runIdempotent, type CommandResponse } from './idempotency.js';
+
+export interface SetupInput {
+  familyName?: string;
+  nickname: string;
+  avatarUrl?: string | null;
+  lessonAgeBand: string;
+}
+
+export interface ProfilePatch {
+  nickname?: string;
+  avatarUrl?: string | null;
+  lessonAgeBand?: string;
+}
+
+export interface AllowanceInput {
+  amountCents: unknown;
+  cadence: 'weekly';
+  weekday: number;
+  startDate: string;
+  endDate?: string | null;
+}
+
+interface OwnedContext {
+  familyId: string;
+  familyName: string;
+  childId: string;
+  nickname: string;
+  avatarUrl: string | null;
+  lessonAgeBand: string;
+  walletId: string;
+  balanceCents: string;
+}
+
+interface LedgerRow {
+  id: string;
+  wallet_id: string;
+  entry_type: string;
+  direction: string;
+  amount_cents: string;
+  balance_before_cents: string;
+  balance_after_cents: string;
+  reason: string | null;
+  loan_id: string | null;
+  recorded_at: Date | string;
+}
+
+interface LoanRow {
+  id: string;
+  principal_cents: string;
+  outstanding_cents: string;
+  purpose: string | null;
+  due_date: string | null;
+  status: 'open' | 'paid';
+  created_at: Date | string;
+  paid_at: Date | string | null;
+}
+
+function isoTimestamp(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function text(value: unknown, fieldName: string, maxLength: number, required = false): string | null {
+  if (value === undefined || value === null) {
+    if (required) throw validationError(`${fieldName} is required.`);
+    return null;
+  }
+  if (typeof value !== 'string') throw validationError(`${fieldName} must be a string.`);
+  const trimmed = value.trim();
+  if (required && trimmed.length === 0) throw validationError(`${fieldName} cannot be empty.`);
+  if (trimmed.length > maxLength) throw validationError(`${fieldName} is too long.`);
+  return trimmed || null;
+}
+
+function formatLedger(row: LedgerRow): Record<string, unknown> {
+  return {
+    id: row.id,
+    type: row.entry_type,
+    direction: row.direction,
+    amountCents: toJsonCents(row.amount_cents),
+    balanceBeforeCents: toJsonCents(row.balance_before_cents),
+    balanceAfterCents: toJsonCents(row.balance_after_cents),
+    reason: row.reason,
+    loanId: row.loan_id,
+    recordedBy: 'parent',
+    recordedAt: isoTimestamp(row.recorded_at),
+  };
+}
+
+function formatLoan(row: LoanRow): Record<string, unknown> {
+  return {
+    id: row.id,
+    principalCents: toJsonCents(row.principal_cents),
+    outstandingCents: toJsonCents(row.outstanding_cents),
+    purpose: row.purpose,
+    dueDate: row.due_date,
+    status: row.status,
+    createdAt: isoTimestamp(row.created_at),
+    paidAt: row.paid_at ? isoTimestamp(row.paid_at) : null,
+  };
+}
+
+async function ownedContext(client: SqlClient, identityId: string): Promise<OwnedContext> {
+  const result = await client.query<OwnedContext>(
+    `
+      SELECT f.id AS "familyId", f.name AS "familyName",
+             c.id AS "childId", c.nickname, c.avatar_url AS "avatarUrl", c.lesson_age_band AS "lessonAgeBand",
+             w.id AS "walletId", w.balance_cents::text AS "balanceCents"
+      FROM families f
+      JOIN children c ON c.family_id = f.id
+      JOIN wallets w ON w.child_id = c.id
+      WHERE f.owner_identity_id = $1
+    `,
+    [identityId],
+  );
+  const context = result.rows[0];
+  if (!context) throw new AppError(409, 'FAMILY_NOT_SETUP', 'Complete parent and Eddie setup before using the wallet.');
+  return context;
+}
+
+async function ledgerEntry(client: SqlClient, walletId: string, entryId: string): Promise<LedgerRow> {
+  const result = await client.query<LedgerRow>(
+    `SELECT id, wallet_id, entry_type, direction, amount_cents::text, balance_before_cents::text,
+            balance_after_cents::text, reason, loan_id, recorded_at
+     FROM ledger_entries WHERE wallet_id = $1 AND id = $2`,
+    [walletId, entryId],
+  );
+  const row = result.rows[0];
+  if (!row) throw new AppError(404, 'ACTIVITY_NOT_FOUND', 'The activity entry was not found.');
+  return row;
+}
+
+async function snapshot(client: SqlClient, identityId: string): Promise<Record<string, unknown>> {
+  const context = await ownedContext(client, identityId);
+  const loanResult = await client.query<LoanRow>(
+    `SELECT id, principal_cents::text, outstanding_cents::text, purpose, due_date, status, created_at, paid_at
+     FROM loans WHERE wallet_id = $1 ORDER BY created_at DESC LIMIT 1`,
+    [context.walletId],
+  );
+  const allowanceResult = await client.query<{
+    id: string;
+    amount_cents: string;
+    cadence: string;
+    weekday: number;
+    start_date: string;
+    end_date: string | null;
+    active: boolean;
+    next_occurrence_id: string | null;
+    next_due_on: string | null;
+  }>(
+    `
+      SELECT r.id, r.amount_cents::text, r.cadence, r.weekday, r.start_date, r.end_date, r.active,
+             (SELECT o.id FROM allowance_occurrences o
+              WHERE o.rule_id = r.id AND o.status = 'scheduled'
+              ORDER BY o.due_on LIMIT 1) AS next_occurrence_id,
+             (SELECT o.due_on FROM allowance_occurrences o
+              WHERE o.rule_id = r.id AND o.status = 'scheduled'
+              ORDER BY o.due_on LIMIT 1) AS next_due_on
+      FROM allowance_rules r WHERE r.wallet_id = $1
+    `,
+    [context.walletId],
+  );
+  const entriesResult = await client.query<LedgerRow>(
+    `SELECT id, wallet_id, entry_type, direction, amount_cents::text, balance_before_cents::text,
+            balance_after_cents::text, reason, loan_id, recorded_at
+     FROM ledger_entries WHERE wallet_id = $1 ORDER BY recorded_at DESC, id DESC LIMIT 10`,
+    [context.walletId],
+  );
+  const loan = loanResult.rows[0];
+  const allowance = allowanceResult.rows[0];
+  return {
+    family: { id: context.familyId, name: context.familyName },
+    child: {
+      id: context.childId,
+      nickname: context.nickname,
+      avatarUrl: context.avatarUrl,
+      lessonAgeBand: context.lessonAgeBand,
+    },
+    wallet: {
+      id: context.walletId,
+      currency: 'USD',
+      balanceCents: toJsonCents(context.balanceCents),
+      virtualNotice: 'Virtual practice only. These dollars are pretend, cannot be redeemed, and never move real money.',
+    },
+    allowanceRule: allowance
+      ? {
+          id: allowance.id,
+          amountCents: toJsonCents(allowance.amount_cents),
+          cadence: allowance.cadence,
+          weekday: allowance.weekday,
+          startDate: allowance.start_date,
+          endDate: allowance.end_date,
+          active: allowance.active,
+          nextOccurrenceId: allowance.next_occurrence_id,
+          nextDueDate: allowance.next_due_on,
+        }
+      : null,
+    loan: loan ? formatLoan(loan) : null,
+    recentActivity: entriesResult.rows.map(formatLedger),
+  };
+}
+
+async function recordLedger(
+  client: SqlClient,
+  input: {
+    walletId: string;
+    actorIdentityId: string;
+    type: 'deposit' | 'withdrawal' | 'allowance' | 'loan' | 'repayment';
+    direction: 'credit' | 'debit';
+    amountCents: bigint;
+    reason: string | null;
+    loanId?: string;
+  },
+): Promise<LedgerRow> {
+  const wallet = await client.query<{ balance_cents: string }>(
+    'SELECT balance_cents::text FROM wallets WHERE id = $1 FOR UPDATE',
+    [input.walletId],
+  );
+  const walletRow = wallet.rows[0];
+  if (!walletRow) throw new AppError(404, 'WALLET_NOT_FOUND', 'The wallet was not found.');
+  const before = BigInt(walletRow.balance_cents);
+  const after = input.direction === 'credit'
+    ? before + input.amountCents
+    : subtractCents(before, input.amountCents, 'The withdrawal or repayment');
+  if (after > MAX_AMOUNT_CENTS) {
+    throw new AppError(409, 'BALANCE_LIMIT_EXCEEDED', 'The resulting virtual balance exceeds the supported limit.');
+  }
+
+  const inserted = await client.query<{ id: string }>(
+    `
+      INSERT INTO ledger_entries
+        (wallet_id, entry_type, direction, amount_cents, balance_before_cents, balance_after_cents,
+         reason, loan_id, recorded_by_identity_id)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      RETURNING id
+    `,
+    [
+      input.walletId,
+      input.type,
+      input.direction,
+      input.amountCents.toString(),
+      before.toString(),
+      after.toString(),
+      input.reason,
+      input.loanId ?? null,
+      input.actorIdentityId,
+    ],
+  );
+  const id = inserted.rows[0]?.id;
+  if (!id) throw new Error('Ledger insert did not return an id.');
+  await client.query("SELECT set_config('eddys_wallet.allow_balance_update', 'on', true)");
+  await client.query('UPDATE wallets SET balance_cents = $1 WHERE id = $2', [after.toString(), input.walletId]);
+  return ledgerEntry(client, input.walletId, id);
+}
+
+function command<T>(
+  db: Database,
+  identityId: string,
+  idempotencyKey: string,
+  requestHash: string,
+  work: (client: SqlClient) => Promise<CommandResponse<T>>,
+): Promise<CommandResponse<T>> {
+  return runIdempotent(db, identityId, idempotencyKey, requestHash, work);
+}
+
+export class WalletService {
+  constructor(private readonly db: Database) {}
+
+  async family(identityId: string): Promise<Record<string, unknown>> {
+    return snapshot(this.db, identityId);
+  }
+
+  async childView(identityId: string): Promise<Record<string, unknown>> {
+    const result = await snapshot(this.db, identityId);
+    return {
+      wallet: result.wallet,
+      child: result.child,
+      allowanceRule: result.allowanceRule,
+      loan: result.loan,
+      recentActivity: result.recentActivity,
+      readOnly: true,
+    };
+  }
+
+  async activity(identityId: string, limit: number): Promise<Record<string, unknown>> {
+    const context = await ownedContext(this.db, identityId);
+    const result = await this.db.query<LedgerRow>(
+      `SELECT id, wallet_id, entry_type, direction, amount_cents::text, balance_before_cents::text,
+              balance_after_cents::text, reason, loan_id, recorded_at
+       FROM ledger_entries WHERE wallet_id = $1 ORDER BY recorded_at DESC, id DESC LIMIT $2`,
+      [context.walletId, limit],
+    );
+    return { entries: result.rows.map(formatLedger), virtualNotice: 'Virtual practice only. These dollars are pretend, cannot be redeemed, and never move real money.' };
+  }
+
+  async activityDetail(identityId: string, entryId: string): Promise<Record<string, unknown>> {
+    const context = await ownedContext(this.db, identityId);
+    const entry = await ledgerEntry(this.db, context.walletId, entryId);
+    return { entry: formatLedger(entry), virtualNotice: 'Virtual practice only. These dollars are pretend, cannot be redeemed, and never move real money.' };
+  }
+
+  async setup(
+    identityId: string,
+    input: SetupInput,
+    idempotencyKey: string,
+    requestHashValue: string,
+  ): Promise<CommandResponse<Record<string, unknown>>> {
+    const familyName = text(input.familyName, 'familyName', 120) ?? "Eddie's family";
+    const nickname = text(input.nickname, 'nickname', 80, true)!;
+    const lessonAgeBand = text(input.lessonAgeBand, 'lessonAgeBand', 32, true)!;
+    const avatarUrl = text(input.avatarUrl, 'avatarUrl', 2048);
+    return command(this.db, identityId, idempotencyKey, requestHashValue, async (client) => {
+      await client.query('SELECT id FROM parent_identities WHERE id = $1 FOR UPDATE', [identityId]);
+      const existing = await client.query('SELECT id FROM families WHERE owner_identity_id = $1 FOR UPDATE', [identityId]);
+      if (existing.rows.length > 0) throw new AppError(409, 'FAMILY_ALREADY_SETUP', 'This parent already has a family.');
+      const family = await client.query<{ id: string }>(
+        'INSERT INTO families (owner_identity_id, name) VALUES ($1, $2) RETURNING id',
+        [identityId, familyName],
+      );
+      const familyId = family.rows[0]?.id;
+      if (!familyId) throw new Error('Family insert did not return an id.');
+      const child = await client.query<{ id: string }>(
+        `INSERT INTO children (family_id, nickname, avatar_url, lesson_age_band)
+         VALUES ($1, $2, $3, $4) RETURNING id`,
+        [familyId, nickname, avatarUrl, lessonAgeBand],
+      );
+      const childId = child.rows[0]?.id;
+      if (!childId) throw new Error('Child insert did not return an id.');
+      await client.query('INSERT INTO wallets (child_id) VALUES ($1)', [childId]);
+      return { statusCode: 201, body: await snapshot(client, identityId) };
+    });
+  }
+
+  async updateProfile(
+    identityId: string,
+    input: ProfilePatch,
+    idempotencyKey: string,
+    requestHashValue: string,
+  ): Promise<CommandResponse<Record<string, unknown>>> {
+    const updates: string[] = [];
+    const values: unknown[] = [];
+    if (input.nickname !== undefined) {
+      updates.push(`nickname = $${values.length + 1}`);
+      values.push(text(input.nickname, 'nickname', 80, true));
+    }
+    if (input.avatarUrl !== undefined) {
+      updates.push(`avatar_url = $${values.length + 1}`);
+      values.push(text(input.avatarUrl, 'avatarUrl', 2048));
+    }
+    if (input.lessonAgeBand !== undefined) {
+      updates.push(`lesson_age_band = $${values.length + 1}`);
+      values.push(text(input.lessonAgeBand, 'lessonAgeBand', 32, true));
+    }
+    if (updates.length === 0) throw validationError('At least one profile field is required.');
+    return command(this.db, identityId, idempotencyKey, requestHashValue, async (client) => {
+      const context = await ownedContext(client, identityId);
+      values.push(context.childId);
+      const updated = await client.query(`UPDATE children SET ${updates.join(', ')} WHERE id = $${values.length} RETURNING id`, values);
+      if (updated.rows.length === 0) throw new AppError(404, 'CHILD_NOT_FOUND', 'Eddie profile was not found.');
+      return { statusCode: 200, body: await snapshot(client, identityId) };
+    });
+  }
+
+  async updateFamily(
+    identityId: string,
+    input: { name: unknown },
+    idempotencyKey: string,
+    requestHashValue: string,
+  ): Promise<CommandResponse<Record<string, unknown>>> {
+    const name = text(input.name, 'name', 120, true)!;
+    return command(this.db, identityId, idempotencyKey, requestHashValue, async (client) => {
+      const context = await ownedContext(client, identityId);
+      await client.query('UPDATE families SET name = $1 WHERE id = $2', [name, context.familyId]);
+      return { statusCode: 200, body: await snapshot(client, identityId) };
+    });
+  }
+
+  async deposit(
+    identityId: string,
+    input: { amountCents: unknown; reason?: unknown },
+    idempotencyKey: string,
+    requestHashValue: string,
+  ): Promise<CommandResponse<Record<string, unknown>>> {
+    const amountCents = parseAmountCents(input.amountCents);
+    const reason = text(input.reason, 'reason', 240);
+    return command(this.db, identityId, idempotencyKey, requestHashValue, async (client) => {
+      const context = await ownedContext(client, identityId);
+      const entry = await recordLedger(client, {
+        walletId: context.walletId,
+        actorIdentityId: identityId,
+        type: 'deposit',
+        direction: 'credit',
+        amountCents,
+        reason,
+      });
+      return { statusCode: 201, body: { entry: formatLedger(entry), wallet: (await snapshot(client, identityId)).wallet } };
+    });
+  }
+
+  async withdrawal(
+    identityId: string,
+    input: { amountCents: unknown; reason?: unknown },
+    idempotencyKey: string,
+    requestHashValue: string,
+  ): Promise<CommandResponse<Record<string, unknown>>> {
+    const amountCents = parseAmountCents(input.amountCents);
+    const reason = text(input.reason, 'reason', 240);
+    return command(this.db, identityId, idempotencyKey, requestHashValue, async (client) => {
+      const context = await ownedContext(client, identityId);
+      const entry = await recordLedger(client, {
+        walletId: context.walletId,
+        actorIdentityId: identityId,
+        type: 'withdrawal',
+        direction: 'debit',
+        amountCents,
+        reason,
+      });
+      return { statusCode: 201, body: { entry: formatLedger(entry), wallet: (await snapshot(client, identityId)).wallet } };
+    });
+  }
+
+  async createLoan(
+    identityId: string,
+    input: { principalCents: unknown; purpose?: unknown; dueDate?: unknown },
+    idempotencyKey: string,
+    requestHashValue: string,
+  ): Promise<CommandResponse<Record<string, unknown>>> {
+    const principalCents = parseAmountCents(input.principalCents, 'principalCents');
+    const purpose = text(input.purpose, 'purpose', 240);
+    const dueDate = input.dueDate === undefined || input.dueDate === null ? null : parseDateOnly(input.dueDate, 'dueDate');
+    return command(this.db, identityId, idempotencyKey, requestHashValue, async (client) => {
+      const context = await ownedContext(client, identityId);
+      await client.query('SELECT id FROM wallets WHERE id = $1 FOR UPDATE', [context.walletId]);
+      const openLoan = await client.query('SELECT id FROM loans WHERE wallet_id = $1 AND status = \'open\' FOR UPDATE', [context.walletId]);
+      if (openLoan.rows.length > 0) throw new AppError(409, 'OPEN_LOAN_EXISTS', 'Only one open loan is supported in the MVP.');
+      const loan = await client.query<{ id: string }>(
+        `INSERT INTO loans (wallet_id, principal_cents, outstanding_cents, purpose, due_date, created_by_identity_id)
+         VALUES ($1, $2, $2, $3, $4, $5) RETURNING id`,
+        [context.walletId, principalCents.toString(), purpose, dueDate, identityId],
+      );
+      const loanId = loan.rows[0]?.id;
+      if (!loanId) throw new Error('Loan insert did not return an id.');
+      const entry = await recordLedger(client, {
+        walletId: context.walletId,
+        actorIdentityId: identityId,
+        type: 'loan',
+        direction: 'credit',
+        amountCents: principalCents,
+        reason: purpose,
+        loanId,
+      });
+      const loanRow = await client.query<LoanRow>(
+        `SELECT id, principal_cents::text, outstanding_cents::text, purpose, due_date, status, created_at, paid_at
+         FROM loans WHERE id = $1`,
+        [loanId],
+      );
+      return {
+        statusCode: 201,
+        body: { loan: loanRow.rows[0] ? formatLoan(loanRow.rows[0]) : null, entry: formatLedger(entry), wallet: (await snapshot(client, identityId)).wallet },
+      };
+    });
+  }
+
+  async repayLoan(
+    identityId: string,
+    loanId: string,
+    input: { amountCents: unknown; reason?: unknown },
+    idempotencyKey: string,
+    requestHashValue: string,
+  ): Promise<CommandResponse<Record<string, unknown>>> {
+    const amountCents = parseAmountCents(input.amountCents);
+    const reason = text(input.reason, 'reason', 240);
+    return command(this.db, identityId, idempotencyKey, requestHashValue, async (client) => {
+      const context = await ownedContext(client, identityId);
+      await client.query('SELECT id FROM wallets WHERE id = $1 FOR UPDATE', [context.walletId]);
+      const loanResult = await client.query<LoanRow>(
+        `SELECT id, principal_cents::text, outstanding_cents::text, purpose, due_date, status, created_at, paid_at
+         FROM loans WHERE id = $1 AND wallet_id = $2 FOR UPDATE`,
+        [loanId, context.walletId],
+      );
+      const loan = loanResult.rows[0];
+      if (!loan) throw new AppError(404, 'LOAN_NOT_FOUND', 'The loan was not found.');
+      const outstanding = BigInt(loan.outstanding_cents);
+      if (loan.status !== 'open' || outstanding === 0n) throw new AppError(409, 'LOAN_ALREADY_PAID', 'The loan is already paid.');
+      if (amountCents > outstanding) throw new AppError(409, 'REPAYMENT_EXCEEDS_OUTSTANDING', 'Repayment cannot exceed the outstanding principal.');
+      const entry = await recordLedger(client, {
+        walletId: context.walletId,
+        actorIdentityId: identityId,
+        type: 'repayment',
+        direction: 'debit',
+        amountCents,
+        reason,
+        loanId,
+      });
+      await client.query(
+        `INSERT INTO repayments (loan_id, ledger_entry_id, amount_cents, recorded_by_identity_id)
+         VALUES ($1, $2, $3, $4)`,
+        [loanId, entry.id, amountCents.toString(), identityId],
+      );
+      const remaining = outstanding - amountCents;
+      await client.query(
+        `UPDATE loans SET outstanding_cents = $1, status = $2, paid_at = CASE WHEN $3 = 0 THEN now() ELSE NULL END WHERE id = $4`,
+        [remaining.toString(), remaining === 0n ? 'paid' : 'open', remaining.toString(), loanId],
+      );
+      const updatedLoan = await client.query<LoanRow>(
+        `SELECT id, principal_cents::text, outstanding_cents::text, purpose, due_date, status, created_at, paid_at
+         FROM loans WHERE id = $1`,
+        [loanId],
+      );
+      return {
+        statusCode: 201,
+        body: { loan: updatedLoan.rows[0] ? formatLoan(updatedLoan.rows[0]) : null, entry: formatLedger(entry), wallet: (await snapshot(client, identityId)).wallet },
+      };
+    });
+  }
+
+  async setAllowance(
+    identityId: string,
+    input: AllowanceInput,
+    idempotencyKey: string,
+    requestHashValue: string,
+  ): Promise<CommandResponse<Record<string, unknown>>> {
+    const amountCents = parseAmountCents(input.amountCents);
+    if (input.cadence !== 'weekly') throw validationError('Only weekly allowance rules are supported in the MVP.');
+    if (!Number.isInteger(input.weekday) || input.weekday < 0 || input.weekday > 6) throw validationError('weekday must be an integer from 0 (Sunday) to 6 (Saturday).');
+    const startDate = parseDateOnly(input.startDate, 'startDate');
+    const endDate = input.endDate === undefined || input.endDate === null ? null : parseDateOnly(input.endDate, 'endDate');
+    if (endDate && endDate < startDate) throw validationError('endDate cannot be before startDate.');
+    return command(this.db, identityId, idempotencyKey, requestHashValue, async (client) => {
+      const context = await ownedContext(client, identityId);
+      await client.query('SELECT id FROM wallets WHERE id = $1 FOR UPDATE', [context.walletId]);
+      const existing = await client.query<{ id: string }>('SELECT id FROM allowance_rules WHERE wallet_id = $1 FOR UPDATE', [context.walletId]);
+      let ruleId: string;
+      if (existing.rows[0]) {
+        ruleId = existing.rows[0].id;
+        await client.query(
+          `UPDATE allowance_rules SET amount_cents = $1, cadence = $2, weekday = $3, start_date = $4, end_date = $5, active = true
+           WHERE id = $6`,
+          [amountCents.toString(), input.cadence, input.weekday, startDate, endDate, ruleId],
+        );
+        await client.query("UPDATE allowance_occurrences SET status = 'cancelled' WHERE rule_id = $1 AND status = 'scheduled'", [ruleId]);
+      } else {
+        const inserted = await client.query<{ id: string }>(
+          `INSERT INTO allowance_rules (wallet_id, amount_cents, cadence, weekday, start_date, end_date, created_by_identity_id)
+           VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id`,
+          [context.walletId, amountCents.toString(), input.cadence, input.weekday, startDate, endDate, identityId],
+        );
+        ruleId = inserted.rows[0]?.id ?? '';
+      }
+      const today = new Date().toISOString().slice(0, 10);
+      let nextDue = nextWeeklyDate(startDate > today ? startDate : today, input.weekday);
+      while (nextDue < today) nextDue = addDays(nextDue, 7);
+      if (!endDate || nextDue <= endDate) {
+        await client.query(
+          `INSERT INTO allowance_occurrences (rule_id, due_on) VALUES ($1, $2) ON CONFLICT (rule_id, due_on) DO NOTHING`,
+          [ruleId, nextDue],
+        );
+      }
+      return { statusCode: 200, body: await snapshot(client, identityId) };
+    });
+  }
+
+  async recordAllowance(
+    identityId: string,
+    ruleId: string,
+    occurrenceId: string,
+    input: { reason?: unknown },
+    idempotencyKey: string,
+    requestHashValue: string,
+  ): Promise<CommandResponse<Record<string, unknown>>> {
+    const reason = text(input.reason, 'reason', 240) ?? 'Allowance';
+    return command(this.db, identityId, idempotencyKey, requestHashValue, async (client) => {
+      const context = await ownedContext(client, identityId);
+      await client.query('SELECT id FROM wallets WHERE id = $1 FOR UPDATE', [context.walletId]);
+      const result = await client.query<{
+        occurrence_id: string;
+        due_on: string;
+        status: string;
+        rule_id: string;
+        amount_cents: string;
+        end_date: string | null;
+        weekday: number;
+        active: boolean;
+      }>(
+        `SELECT o.id AS occurrence_id, o.due_on, o.status, r.id AS rule_id, r.amount_cents::text, r.end_date, r.weekday, r.active
+         FROM allowance_occurrences o JOIN allowance_rules r ON r.id = o.rule_id
+         WHERE o.id = $1 AND o.rule_id = $2 AND r.wallet_id = $3 FOR UPDATE`,
+        [occurrenceId, ruleId, context.walletId],
+      );
+      const occurrence = result.rows[0];
+      if (!occurrence) throw new AppError(404, 'ALLOWANCE_OCCURRENCE_NOT_FOUND', 'The allowance occurrence was not found.');
+      if (!occurrence.active || occurrence.status !== 'scheduled') throw new AppError(409, 'ALLOWANCE_NOT_SCHEDULED', 'This allowance occurrence is no longer scheduled.');
+      const entry = await recordLedger(client, {
+        walletId: context.walletId,
+        actorIdentityId: identityId,
+        type: 'allowance',
+        direction: 'credit',
+        amountCents: BigInt(occurrence.amount_cents),
+        reason,
+      });
+      await client.query(
+        "UPDATE allowance_occurrences SET status = 'recorded', accepted_entry_id = $1 WHERE id = $2",
+        [entry.id, occurrenceId],
+      );
+      const nextDue = addDays(occurrence.due_on, 7);
+      if (!occurrence.end_date || nextDue <= occurrence.end_date) {
+        await client.query(
+          `INSERT INTO allowance_occurrences (rule_id, due_on) VALUES ($1, $2) ON CONFLICT (rule_id, due_on) DO NOTHING`,
+          [ruleId, nextDue],
+        );
+      }
+      return { statusCode: 201, body: { entry: formatLedger(entry), wallet: (await snapshot(client, identityId)).wallet } };
+    });
+  }
+
+  async loanDetail(identityId: string, loanId: string): Promise<Record<string, unknown>> {
+    const context = await ownedContext(this.db, identityId);
+    const loanResult = await this.db.query<LoanRow>(
+      `SELECT id, principal_cents::text, outstanding_cents::text, purpose, due_date, status, created_at, paid_at
+       FROM loans WHERE id = $1 AND wallet_id = $2`,
+      [loanId, context.walletId],
+    );
+    const loan = loanResult.rows[0];
+    if (!loan) throw new AppError(404, 'LOAN_NOT_FOUND', 'The loan was not found.');
+    const entries = await this.db.query<LedgerRow>(
+      `SELECT id, wallet_id, entry_type, direction, amount_cents::text, balance_before_cents::text,
+              balance_after_cents::text, reason, loan_id, recorded_at
+       FROM ledger_entries WHERE wallet_id = $1 AND loan_id = $2 ORDER BY recorded_at ASC, id ASC`,
+      [context.walletId, loanId],
+    );
+    return {
+      loan: formatLoan(loan),
+      repaymentsAndLoanEntry: entries.rows.map(formatLedger),
+      virtualNotice: 'Virtual practice only. These dollars are pretend, cannot be redeemed, and never move real money.',
+    };
+  }
+}

--- a/backend/tests/api.integration.test.ts
+++ b/backend/tests/api.integration.test.ts
@@ -1,0 +1,149 @@
+import type { LightMyRequestResponse } from 'fastify';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createApp } from '../src/app.js';
+import { loadConfig } from '../src/config.js';
+import { Database } from '../src/db/client.js';
+import { runMigrations } from '../src/db/migrate.js';
+
+describe.skipIf(!process.env.DATABASE_URL)('authoritative API and PostgreSQL path', () => {
+  const databaseUrl = process.env.DATABASE_URL as string;
+  const db = new Database(databaseUrl);
+  const app = createApp({
+    db,
+    config: loadConfig({ NODE_ENV: 'test', AUTH_MODE: 'local', DATABASE_URL: databaseUrl }),
+  });
+  let parentToken = '';
+  let otherParentToken = '';
+  let loanId = '';
+  let walletId = '';
+  let depositEntryId = '';
+
+  async function request(method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE', url: string, body?: Record<string, unknown>, token?: string, key?: string): Promise<LightMyRequestResponse> {
+    return await app.inject({
+      method,
+      url,
+      headers: {
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+        ...(key ? { 'idempotency-key': key } : {}),
+      },
+      ...(body === undefined ? {} : { payload: body }),
+    });
+  }
+
+  beforeAll(async () => {
+    await runMigrations(databaseUrl);
+    await app.ready();
+    const first = await request('POST', '/v1/auth/local', { subject: `integration-parent-${Date.now()}` });
+    const second = await request('POST', '/v1/auth/local', { subject: `integration-other-${Date.now()}` });
+    parentToken = first.json().token;
+    otherParentToken = second.json().token;
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await db.close();
+  });
+
+  it('enforces setup ownership and read-only child view boundaries', async () => {
+    const otherRead = await request('GET', '/v1/wallet', undefined, otherParentToken);
+    expect(otherRead.statusCode).toBe(409);
+    expect(otherRead.json().error.code).toBe('FAMILY_NOT_SETUP');
+
+    const setup = await request(
+      'POST',
+      '/v1/family/setup',
+      { nickname: 'Eddie', lessonAgeBand: 'school-age' },
+      parentToken,
+      'setup-1',
+    );
+    expect(setup.statusCode).toBe(201);
+    walletId = setup.json().wallet.id;
+    expect(setup.json().wallet.balanceCents).toBe(0);
+    expect(setup.json().wallet.virtualNotice).toContain('cannot be redeemed');
+
+    const childView = await request('GET', '/v1/child-view', undefined, parentToken);
+    expect(childView.statusCode).toBe(200);
+    expect(childView.json().readOnly).toBe(true);
+    expect(childView.json().parent).toBeUndefined();
+  });
+
+  it('applies money commands exactly once and rejects overdrafts', async () => {
+    const deposit = await request('POST', '/v1/wallet/deposits', { amountCents: 150, reason: 'first deposit' }, parentToken, 'deposit-1');
+    expect(deposit.statusCode).toBe(201);
+    depositEntryId = deposit.json().entry.id;
+    expect(deposit.json().wallet.balanceCents).toBe(150);
+
+    const otherWrite = await request('POST', '/v1/wallet/deposits', { amountCents: 1 }, otherParentToken, 'other-write');
+    expect(otherWrite.statusCode).toBe(409);
+    expect(otherWrite.json().error.code).toBe('FAMILY_NOT_SETUP');
+    const otherActivity = await request('GET', `/v1/activity/${depositEntryId}`, undefined, otherParentToken);
+    expect(otherActivity.statusCode).toBe(409);
+    expect(otherActivity.json().error.code).toBe('FAMILY_NOT_SETUP');
+
+    const replay = await request('POST', '/v1/wallet/deposits', { reason: 'first deposit', amountCents: 150 }, parentToken, 'deposit-1');
+    expect(replay.statusCode).toBe(201);
+    expect(replay.json()).toEqual(deposit.json());
+
+    const changedReplay = await request('POST', '/v1/wallet/deposits', { amountCents: 151 }, parentToken, 'deposit-1');
+    expect(changedReplay.statusCode).toBe(409);
+    expect(changedReplay.json().error.code).toBe('IDEMPOTENCY_KEY_REUSED');
+
+    const withdrawal = await request('POST', '/v1/wallet/withdrawals', { amountCents: 151 }, parentToken, 'withdrawal-too-large');
+    expect(withdrawal.statusCode).toBe(409);
+    const balance = await request('GET', '/v1/wallet', undefined, parentToken);
+    expect(balance.json().wallet.balanceCents).toBe(150);
+
+    const count = await db.query<{ count: string }>("SELECT count(*)::text FROM ledger_entries WHERE wallet_id = $1 AND entry_type = 'deposit'", [walletId]);
+    expect(count.rows[0]?.count).toBe('1');
+  });
+
+  it('limits loans and repayments to explicit integer principal and available balance', async () => {
+    const loan = await request('POST', '/v1/loans', { principalCents: 1000, purpose: 'bike' }, parentToken, 'loan-1');
+    expect(loan.statusCode).toBe(201);
+    loanId = loan.json().loan.id;
+    expect(loan.json().wallet.balanceCents).toBe(1150);
+
+    const tooMuch = await request('POST', `/v1/loans/${loanId}/repayments`, { amountCents: 1001 }, parentToken, 'repay-too-large');
+    expect(tooMuch.statusCode).toBe(409);
+    expect(tooMuch.json().error.code).toBe('REPAYMENT_EXCEEDS_OUTSTANDING');
+
+    const partial = await request('POST', `/v1/loans/${loanId}/repayments`, { amountCents: 500 }, parentToken, 'repay-1');
+    expect(partial.statusCode).toBe(201);
+    expect(partial.json().loan.outstandingCents).toBe(500);
+
+    const full = await request('POST', `/v1/loans/${loanId}/repayments`, { amountCents: 500 }, parentToken, 'repay-2');
+    expect(full.statusCode).toBe(201);
+    expect(full.json().loan.status).toBe('paid');
+    expect(full.json().wallet.balanceCents).toBe(150);
+  });
+
+  it('stores a weekly allowance rule and records a scheduled occurrence', async () => {
+    const rule = await request(
+      'PUT',
+      '/v1/allowance-rule',
+      { amountCents: 250, cadence: 'weekly', weekday: 5, startDate: '2099-01-01' },
+      parentToken,
+      'allowance-1',
+    );
+    expect(rule.statusCode).toBe(200);
+    const allowance = rule.json().allowanceRule;
+    expect(allowance.amountCents).toBe(250);
+    expect(allowance.nextOccurrenceId).toBeTruthy();
+
+    const occurrence = await request(
+      'POST',
+      `/v1/allowance-rule/${allowance.id}/occurrences/${allowance.nextOccurrenceId}/record`,
+      {},
+      parentToken,
+      'allowance-occurrence-1',
+    );
+    expect(occurrence.statusCode).toBe(201);
+    expect(occurrence.json().wallet.balanceCents).toBe(400);
+  });
+
+  it('protects accepted ledger entries from mutation', async () => {
+    await expect(db.query("UPDATE ledger_entries SET reason = 'tampered'"),).rejects.toThrow();
+    await expect(db.query('DELETE FROM ledger_entries'),).rejects.toThrow();
+    await expect(db.query("UPDATE repayments SET amount_cents = 1"),).rejects.toThrow();
+  });
+});

--- a/backend/tests/config.test.ts
+++ b/backend/tests/config.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { loadConfig } from '../src/config.js';
+
+describe('configuration safety', () => {
+  it('rejects local auth in production', () => {
+    expect(() => loadConfig({ NODE_ENV: 'production', AUTH_MODE: 'local' })).toThrow(/production/);
+  });
+
+  it('requires Apple audience in Apple mode', () => {
+    expect(() => loadConfig({ NODE_ENV: 'test', AUTH_MODE: 'apple' })).toThrow(/APPLE_AUDIENCES/);
+    const config = loadConfig({ NODE_ENV: 'test', AUTH_MODE: 'apple', APPLE_AUDIENCES: 'com.example.app' });
+    expect(config.appleAudiences).toEqual(['com.example.app']);
+    expect(config.appleNonceRequired).toBe(true);
+  });
+});

--- a/backend/tests/deployment-contract.test.ts
+++ b/backend/tests/deployment-contract.test.ts
@@ -1,0 +1,39 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+async function fileAt(relativePath: string): Promise<string> {
+  return readFile(resolve(repositoryRoot, relativePath), 'utf8');
+}
+
+describe('production and local container contracts', () => {
+  it('keeps the production image aligned with internal port 8080', async () => {
+    const dockerfile = await fileAt('backend/Dockerfile');
+    const productionCompose = await fileAt('deploy/compose.yaml');
+    const caddyfile = await fileAt('deploy/Caddyfile');
+
+    expect(dockerfile).toMatch(/ENV PORT=8080/);
+    expect(dockerfile).toMatch(/EXPOSE 8080/);
+    expect(productionCompose).toMatch(/expose:\s+- "8080"/);
+    expect(productionCompose).toMatch(/127\.0\.0\.1:8080\/healthz/);
+    expect(caddyfile).toContain('reverse_proxy backend:8080');
+  });
+
+  it('keeps local development on port 3000', async () => {
+    const localCompose = await fileAt('backend/docker-compose.yml');
+    expect(localCompose).toMatch(/PORT: 3000/);
+    expect(localCompose).toContain('"3000:3000"');
+  });
+
+  it('uses the compiled migration entrypoint in deployment configuration', async () => {
+    const deployEnv = await fileAt('deploy/.env.example');
+    const deployReadme = await fileAt('deploy/README.md');
+    const migrationCommand = 'node dist/src/db/migrate.js';
+
+    expect(deployEnv).toContain(`MIGRATION_COMMAND=${migrationCommand}`);
+    expect(deployReadme).toContain(`MIGRATION_COMMAND='${migrationCommand}'`);
+  });
+});

--- a/backend/tests/money.test.ts
+++ b/backend/tests/money.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { parseAmountCents, subtractCents, toJsonCents } from '../src/domain/money.js';
+
+describe('integer-cent arithmetic', () => {
+  it('accepts exact integer cents and returns bigint', () => {
+    expect(parseAmountCents(125)).toBe(125n);
+    expect(parseAmountCents('9000000000000')).toBe(9_000_000_000_000n);
+  });
+
+  it('rejects zero, negative, fractional, and unsafe amounts', () => {
+    expect(() => parseAmountCents(0)).toThrow();
+    expect(() => parseAmountCents(-1)).toThrow();
+    expect(() => parseAmountCents(1.5)).toThrow();
+    expect(() => parseAmountCents(Number.MAX_SAFE_INTEGER + 1)).toThrow();
+  });
+
+  it('never permits a debit below zero', () => {
+    expect(subtractCents(100n, 100n, 'debit')).toBe(0n);
+    expect(() => subtractCents(99n, 100n, 'debit')).toThrow();
+  });
+
+  it('serializes only safe JSON integer cents', () => {
+    expect(toJsonCents(123n)).toBe(123);
+  });
+});

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": ".",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "sourceMap": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    testTimeout: 15_000,
+    hookTimeout: 15_000,
+  },
+});

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -8,4 +8,4 @@ POSTGRES_PASSWORD=SET_ON_HOST_ONLY
 # The application must read these same connection values from its environment.
 DATABASE_URL=postgresql://eddies_wallet:SET_ON_HOST_ONLY@db:5432/eddies_wallet
 # Required by the migration command on the host. Keep the command explicit.
-MIGRATION_COMMAND=./bin/migrate
+MIGRATION_COMMAND=node dist/src/db/migrate.js

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -34,8 +34,9 @@ until a backend image is selected and reviewed.
 3. Copy this directory with `REMOTE_HOST` set in the invoking shell. Create the
    host-only `deploy/.env` from `.env.example`, using an immutable backend image
    reference and real database credentials only on the host.
-4. Set `MIGRATION_COMMAND` to the backend's reviewed migration command and run
-   `migrate.sh` before `deploy.sh` starts the Compose project.
+4. Set `MIGRATION_COMMAND=node dist/src/db/migrate.js` to the backend
+   image's reviewed migration command and run `migrate.sh` before `deploy.sh`
+   starts the Compose project.
 5. Set `HEALTHCHECK_URL` to the later domain's health endpoint and run
    `healthcheck.sh` after deployment.
 
@@ -43,7 +44,7 @@ Example command shapes, with placeholders intentionally left unresolved:
 
 ```sh
 REMOTE_HOST='<server-address>' REMOTE_USER=eddies ./deploy/deploy.sh
-REMOTE_HOST='<server-address>' MIGRATION_COMMAND='./bin/migrate' ./deploy/migrate.sh
+REMOTE_HOST='<server-address>' MIGRATION_COMMAND='node dist/src/db/migrate.js' ./deploy/migrate.sh
 HEALTHCHECK_URL='https://<domain>/healthz' ./deploy/healthcheck.sh
 REMOTE_HOST='<server-address>' ROLLBACK_BACKEND_IMAGE='<old-immutable-image>' ./deploy/rollback.sh
 ```


### PR DESCRIPTION
## Summary
- add a TypeScript/Fastify/PostgreSQL backend under `backend/` with Docker Compose development services
- add versioned identity, session, family, child, wallet, immutable ledger, allowance, loan, repayment, and idempotency migrations
- add Apple JWKS identity verification with issuer, audience, and nonce checks plus development-only local auth
- add parent-owned setup/profile, read-only wallet/activity/child views, allowance, deposit, withdrawal, loan, and repayment APIs
- enforce integer cents, transactional balance and repayment limits, immutable accepted events, and idempotent command replay

## Validation
- `npm run lint`
- `npm test`
- `DATABASE_URL=postgresql://postgres@localhost:5433/eddys_wallet npm run test:integration`
- `npm run build`
- `docker compose build api`
- Compose API health check at `/healthz`

## Explicit MVP boundaries
Weekly allowances are parent-confirmed without a background scheduler. There is one authenticated parent owner and one Eddie profile. Offline queueing, PIN recovery, backups/exports, retention policy, and final Hetzner operations ownership remain product or launch decisions. No Google auth, payments, child login, interest, or multiple wallets are included.