### PR TITLE
Connect iOS app to production wallet API

### DIFF
--- a/EddysWallet.xcodeproj/project.pbxproj
+++ b/EddysWallet.xcodeproj/project.pbxproj
@@ -16,6 +16,11 @@
 		301000000000000000000007 /* LessonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207000000000000000000001 /* LessonView.swift */; };
 		301000000000000000000008 /* WalletView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208000000000000000000001 /* WalletView.swift */; };
 		301000000000000000000009 /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209000000000000000000001 /* WelcomeView.swift */; };
+		301000000000000000000010 /* WalletAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204000000000000000000002 /* WalletAPI.swift */; };
+		301000000000000000000011 /* AppleSignIn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204000000000000000000003 /* AppleSignIn.swift */; };
+		301000000000000000000012 /* SetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D000000000000000000001 /* SetupView.swift */; };
+		301000000000000000000014 /* ParentPINSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20F000000000000000000001 /* ParentPINSetupView.swift */; };
+		301000000000000000000013 /* APIRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E000000000000000000001 /* APIRepositoryTests.swift */; };
 		30100000000000000000000A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 20A000000000000000000001 /* Assets.xcassets */; };
 		30100000000000000000000B /* WalletTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B000000000000000000001 /* WalletTests.swift */; };
 /* End PBXBuildFile section */
@@ -32,6 +37,12 @@
 		209000000000000000000001 /* WelcomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
 		20A000000000000000000001 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		20B000000000000000000001 /* WalletTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletTests.swift; sourceTree = "<group>"; };
+		20C000000000000000000001 /* EddysWallet.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = EddysWallet.entitlements; sourceTree = "<group>"; };
+		20D000000000000000000001 /* SetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupView.swift; sourceTree = "<group>"; };
+		20E000000000000000000001 /* APIRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRepositoryTests.swift; sourceTree = "<group>"; };
+		20F000000000000000000001 /* ParentPINSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentPINSetupView.swift; sourceTree = "<group>"; };
+		204000000000000000000002 /* WalletAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletAPI.swift; sourceTree = "<group>"; };
+		204000000000000000000003 /* AppleSignIn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignIn.swift; sourceTree = "<group>"; };
 		210000000000000000000001 /* EddysWallet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EddysWallet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		211000000000000000000001 /* EddysWalletTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EddysWalletTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -62,6 +73,7 @@
 			isa = PBXGroup;
 			children = (
 				201000000000000000000001 /* EddysWalletApp.swift */,
+				20C000000000000000000001 /* EddysWallet.entitlements */,
 				120000000000000000000001 /* DesignSystem */,
 				119000000000000000000001 /* Models */,
 				121000000000000000000001 /* Views */,
@@ -75,6 +87,8 @@
 			children = (
 				203000000000000000000001 /* WalletModels.swift */,
 				204000000000000000000001 /* WalletStore.swift */,
+				204000000000000000000002 /* WalletAPI.swift */,
+				204000000000000000000003 /* AppleSignIn.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -92,6 +106,8 @@
 			children = (
 				205000000000000000000001 /* DetailViews.swift */,
 				206000000000000000000001 /* FlowViews.swift */,
+				20D000000000000000000001 /* SetupView.swift */,
+				20F000000000000000000001 /* ParentPINSetupView.swift */,
 				207000000000000000000001 /* LessonView.swift */,
 				208000000000000000000001 /* WalletView.swift */,
 				209000000000000000000001 /* WelcomeView.swift */,
@@ -103,6 +119,7 @@
 			isa = PBXGroup;
 			children = (
 				20B000000000000000000001 /* WalletTests.swift */,
+				20E000000000000000000001 /* APIRepositoryTests.swift */,
 			);
 			path = EddysWalletTests;
 			sourceTree = "<group>";
@@ -151,7 +168,12 @@
 				BuildIndependentTargetsInParallel = 1;
 				LastUpgradeCheck = 2640;
 				TargetAttributes = {
-					114000000000000000000001 = { CreatedOnToolsVersion = 26.4; };
+					114000000000000000000001 = {
+						CreatedOnToolsVersion = 26.4;
+						SystemCapabilities = {
+							com.apple.SignInWithApple = { enabled = 1; };
+						};
+					};
 					115000000000000000000001 = { CreatedOnToolsVersion = 26.4; TestTargetID = 114000000000000000000001; };
 				};
 			};
@@ -205,6 +227,10 @@
 				301000000000000000000007 /* LessonView.swift in Sources */,
 				301000000000000000000008 /* WalletView.swift in Sources */,
 				301000000000000000000009 /* WelcomeView.swift in Sources */,
+				301000000000000000000010 /* WalletAPI.swift in Sources */,
+				301000000000000000000011 /* AppleSignIn.swift in Sources */,
+				301000000000000000000012 /* SetupView.swift in Sources */,
+				301000000000000000000014 /* ParentPINSetupView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -213,6 +239,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				30100000000000000000000B /* WalletTests.swift in Sources */,
+				301000000000000000000013 /* APIRepositoryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -259,6 +286,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = EddysWallet/EddysWallet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
@@ -286,6 +314,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = EddysWallet/EddysWallet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/EddysWallet/EddysWallet.entitlements
+++ b/EddysWallet/EddysWallet.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/EddysWallet/EddysWalletApp.swift
+++ b/EddysWallet/EddysWalletApp.swift
@@ -18,10 +18,14 @@ struct RootView: View {
 
     var body: some View {
         Group {
-            if store.isSignedIn {
-                WalletView()
-            } else {
+            if !store.isSignedIn {
                 WelcomeView()
+            } else if store.needsSetup {
+                SetupView()
+            } else if store.needsPINSetup {
+                ParentPINSetupView()
+            } else {
+                WalletView()
             }
         }
         .preferredColorScheme(.light)

--- a/EddysWallet/Models/AppleSignIn.swift
+++ b/EddysWallet/Models/AppleSignIn.swift
@@ -1,0 +1,99 @@
+import AuthenticationServices
+import UIKit
+
+@MainActor
+public final class AppleSignInCoordinator: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
+    private let authenticator: any ParentAuthenticator
+    private var continuation: CheckedContinuation<AuthSession, Error>?
+    private var expectedState: String?
+    private var expectedSignedNonce: String?
+
+    public init(authenticator: any ParentAuthenticator) {
+        self.authenticator = authenticator
+    }
+
+    public func signIn() async throws -> AuthSession {
+        guard continuation == nil else {
+            throw WalletAPIError.server(statusCode: 409, code: "AUTHENTICATION_IN_PROGRESS", message: "Sign in is already in progress.")
+        }
+        let rawNonce = try AppleNonce.randomString()
+        let signedNonce = AppleNonce.sha256(rawNonce)
+        let state = try AppleNonce.randomString()
+        expectedState = state
+        expectedSignedNonce = signedNonce
+
+        let request = ASAuthorizationAppleIDProvider().createRequest()
+        request.requestedScopes = [.email]
+        // Apple signs the SHA-256 nonce into the identity token. The same signed
+        // nonce is sent to the API, which verifies it against that claim.
+        request.nonce = signedNonce
+        request.state = state
+        let controller = ASAuthorizationController(authorizationRequests: [request])
+        controller.delegate = self
+        controller.presentationContextProvider = self
+
+        return try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            controller.performRequests()
+        }
+    }
+
+    public func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithAuthorization authorization: ASAuthorization
+    ) {
+        guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+            finish(.failure(WalletAPIError.invalidResponse("Apple Sign In returned an unsupported credential.")))
+            return
+        }
+        guard credential.state == expectedState else {
+            finish(.failure(WalletAPIError.invalidResponse("Apple Sign In state verification failed.")))
+            return
+        }
+        guard let identityToken = credential.identityToken,
+              let identityTokenString = String(data: identityToken, encoding: .utf8),
+              !identityTokenString.isEmpty,
+              let signedNonce = expectedSignedNonce else {
+            finish(.failure(WalletAPIError.invalidResponse("Apple Sign In did not return an identity token.")))
+            return
+        }
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                let session = try await authenticator.authenticateApple(identityToken: identityTokenString, nonce: signedNonce)
+                finish(.success(session))
+            } catch {
+                finish(.failure(error))
+            }
+        }
+    }
+
+    public func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithError error: Error
+    ) {
+        if let authorizationError = error as? ASAuthorizationError,
+           authorizationError.code == .canceled {
+            finish(.failure(WalletAPIError.cancelled))
+        } else {
+            finish(.failure(WalletAPIError.network("Apple Sign In could not be completed. Please try again.")))
+        }
+    }
+
+    public func presentationAnchor(for _: ASAuthorizationController) -> ASPresentationAnchor {
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        return scenes
+            .flatMap(\.windows)
+            .first(where: \.isKeyWindow)
+            ?? ASPresentationAnchor()
+    }
+
+    private func finish(_ result: Result<AuthSession, Error>) {
+        let continuation = continuation
+        self.continuation = nil
+        expectedState = nil
+        expectedSignedNonce = nil
+        continuation?.resume(with: result)
+    }
+}

--- a/EddysWallet/Models/WalletAPI.swift
+++ b/EddysWallet/Models/WalletAPI.swift
@@ -1,0 +1,890 @@
+import CryptoKit
+import Foundation
+import Security
+
+public enum APIConfiguration {
+    /// The only shipped API environment. The backend operator must provision this
+    /// host and TLS before a real-account simulator test can pass.
+    public static let productionBaseURL = URL(string: "https://api.eddyswallet.com")!
+    public static let productionBaseURLString = "https://api.eddyswallet.com"
+}
+
+public enum WalletAPIError: Error, Equatable, LocalizedError {
+    case noSession
+    case unauthorized
+    case familyNotSetup
+    case cancelled
+    case server(statusCode: Int, code: String, message: String)
+    case network(String)
+    case invalidResponse(String)
+    case invalidConfiguration
+
+    public var errorDescription: String? {
+        switch self {
+        case .noSession: "Sign in with Apple before opening the wallet."
+        case .unauthorized: "Your parent session expired. Sign in with Apple again."
+        case .familyNotSetup: "Finish parent and Eddie setup before opening the wallet."
+        case .cancelled: "Sign in was cancelled."
+        case let .server(_, _, message): message
+        case let .network(message): message
+        case let .invalidResponse(message): message
+        case .invalidConfiguration: "The production API URL is not configured correctly."
+        }
+    }
+}
+
+@MainActor
+public protocol SessionStore: AnyObject {
+    var session: AuthSession? { get }
+    func save(_ session: AuthSession) throws
+    func clear()
+}
+
+@MainActor
+public final class KeychainSessionStore: SessionStore {
+    private let service: String
+    private let account = "parent-session"
+
+    public init(service: String = "com.kunchenguid.eddyswallet.session") {
+        self.service = service
+    }
+
+    public var session: AuthSession? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let data = result as? Data,
+              let decoded = try? JSONDecoder().decode(AuthSession.self, from: data),
+              !decoded.isExpired else {
+            if result != nil { clear() }
+            return nil
+        }
+        return decoded
+    }
+
+    public func save(_ session: AuthSession) throws {
+        let data = try JSONEncoder().encode(session)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        let attributes: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        ]
+        let status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        if status == errSecItemNotFound {
+            var item = query
+            attributes.forEach { item[$0.key] = $0.value }
+            let addStatus = SecItemAdd(item as CFDictionary, nil)
+            guard addStatus == errSecSuccess else { throw KeychainError(status: addStatus) }
+        } else if status != errSecSuccess {
+            throw KeychainError(status: status)
+        }
+    }
+
+    public func clear() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+
+    private struct KeychainError: Error {
+        let status: OSStatus
+    }
+}
+
+@MainActor
+public protocol ParentPINStore: AnyObject {
+    var pin: String? { get }
+    func save(pin: String) throws
+    func clear()
+}
+
+@MainActor
+public final class KeychainParentPINStore: ParentPINStore {
+    private let service = "com.kunchenguid.eddyswallet.parent-pin"
+    private let account = "parent-pin"
+
+    public init() {}
+
+    public var pin: String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let data = result as? Data,
+              let pin = String(data: data, encoding: .utf8),
+              pin.count == 4 else { return nil }
+        return pin
+    }
+
+    public func save(pin: String) throws {
+        guard pin.count == 4, pin.allSatisfy(\.isNumber) else {
+            throw WalletAPIError.invalidResponse("The parent PIN must contain four digits.")
+        }
+        let data = Data(pin.utf8)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        let attributes: [String: Any] = [
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        ]
+        let status = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        if status == errSecItemNotFound {
+            var item = query
+            attributes.forEach { item[$0.key] = $0.value }
+            let addStatus = SecItemAdd(item as CFDictionary, nil)
+            guard addStatus == errSecSuccess else { throw WalletAPIError.invalidResponse("The parent PIN could not be stored securely.") }
+        } else if status != errSecSuccess {
+            throw WalletAPIError.invalidResponse("The parent PIN could not be stored securely.")
+        }
+    }
+
+    public func clear() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}
+
+@MainActor
+public final class InMemoryParentPINStore: ParentPINStore {
+    public private(set) var pin: String?
+
+    public init(pin: String? = nil) { self.pin = pin }
+    public func save(pin: String) throws { self.pin = pin }
+    public func clear() { pin = nil }
+}
+
+@MainActor
+public final class InMemorySessionStore: SessionStore {
+    public private(set) var session: AuthSession?
+
+    public init(session: AuthSession? = nil) {
+        self.session = session
+    }
+
+    public func save(_ session: AuthSession) throws { self.session = session }
+    public func clear() { session = nil }
+}
+
+public protocol HTTPTransport {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+public struct URLSessionTransport: HTTPTransport {
+    private let session: URLSession
+
+    public init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await session.data(for: request)
+    }
+}
+
+@MainActor
+public protocol WalletSnapshotCache: AnyObject {
+    func load() -> WalletSnapshot?
+    func save(_ snapshot: WalletSnapshot)
+    func clear()
+}
+
+@MainActor
+public protocol PendingCommandStore: AnyObject {
+    func load() -> [WalletCommand]
+    func save(_ commands: [WalletCommand])
+    func clear()
+}
+
+@MainActor
+public final class UserDefaultsPendingCommandStore: PendingCommandStore {
+    private let defaults: UserDefaults
+    private let key = "wallet.pending-commands.v1"
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public func load() -> [WalletCommand] {
+        guard let data = defaults.data(forKey: key) else { return [] }
+        return (try? JSONDecoder().decode([WalletCommand].self, from: data)) ?? []
+    }
+
+    public func save(_ commands: [WalletCommand]) {
+        guard let data = try? JSONEncoder().encode(commands) else { return }
+        defaults.set(data, forKey: key)
+    }
+
+    public func clear() { defaults.removeObject(forKey: key) }
+}
+
+@MainActor
+public final class InMemoryPendingCommandStore: PendingCommandStore {
+    private var commands: [WalletCommand]
+
+    public init(commands: [WalletCommand] = []) {
+        self.commands = commands
+    }
+
+    public func load() -> [WalletCommand] { commands }
+    public func save(_ commands: [WalletCommand]) { self.commands = commands }
+    public func clear() { commands = [] }
+}
+
+@MainActor
+public final class UserDefaultsWalletSnapshotCache: WalletSnapshotCache {
+    private let defaults: UserDefaults
+    private let key = "wallet.snapshot.v1"
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public func load() -> WalletSnapshot? {
+        guard let data = defaults.data(forKey: key) else { return nil }
+        return try? JSONDecoder().decode(WalletSnapshot.self, from: data)
+    }
+
+    public func save(_ snapshot: WalletSnapshot) {
+        guard let data = try? JSONEncoder().encode(snapshot) else { return }
+        defaults.set(data, forKey: key)
+    }
+
+    public func clear() { defaults.removeObject(forKey: key) }
+}
+
+private enum WalletVocabulary {
+    static let virtualNotice = "Virtual practice only. These dollars are pretend, cannot be redeemed, and never move real money."
+}
+
+private struct FlexibleInt: Decodable {
+    let value: Int
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let number = try? container.decode(Int.self) {
+            value = number
+        } else {
+            let string = try container.decode(String.self)
+            guard let number = Int(string) else {
+                throw WalletAPIError.invalidResponse("The server returned an invalid money amount.")
+            }
+            value = number
+        }
+    }
+}
+
+private struct ErrorEnvelope: Decodable {
+    struct APIError: Decodable {
+        let code: String
+        let message: String
+    }
+
+    let error: APIError
+}
+
+private struct AuthResponseDTO: Decodable {
+    let token: String
+    let expiresAt: String
+}
+
+private struct WalletDTO: Decodable {
+    let balanceCents: FlexibleInt
+    let virtualNotice: String
+}
+
+private struct EntryDTO: Decodable {
+    let id: String
+    let type: String
+    let direction: String
+    let amountCents: FlexibleInt
+    let balanceBeforeCents: FlexibleInt?
+    let balanceAfterCents: FlexibleInt?
+    let reason: String?
+    let recordedAt: String
+}
+
+private struct LoanDTO: Decodable {
+    let id: String
+    let principalCents: FlexibleInt
+    let outstandingCents: FlexibleInt
+    let purpose: String?
+    let dueDate: String?
+    let status: String
+    let createdAt: String
+    let paidAt: String?
+}
+
+private struct AllowanceDTO: Decodable {
+    let id: String
+    let amountCents: FlexibleInt
+    let cadence: String
+    let weekday: Int
+    let startDate: String
+    let endDate: String?
+    let active: Bool
+    let nextOccurrenceId: String?
+    let nextDueDate: String?
+}
+
+private struct SnapshotDTO: Decodable {
+    let wallet: WalletDTO
+    let allowanceRule: AllowanceDTO?
+    let loan: LoanDTO?
+    let recentActivity: [EntryDTO]
+    let readOnly: Bool?
+}
+
+private struct CommandDTO: Decodable {
+    let entry: EntryDTO
+    let wallet: WalletDTO
+    let loan: LoanDTO?
+}
+
+private struct ActivityListDTO: Decodable {
+    let entries: [EntryDTO]
+    let virtualNotice: String
+}
+
+private struct ActivityDetailDTO: Decodable {
+    let entry: EntryDTO
+    let virtualNotice: String
+}
+
+private struct LoanDetailDTO: Decodable {
+    let loan: LoanDTO
+    let repaymentsAndLoanEntry: [EntryDTO]
+    let virtualNotice: String
+}
+
+@MainActor
+public final class APIWalletRepository: WalletRepository, ParentAuthenticator {
+    private let baseURL: URL
+    private let sessionStore: any SessionStore
+    private let transport: any HTTPTransport
+    private let cache: any WalletSnapshotCache
+    private let pendingStore: any PendingCommandStore
+    private var current: WalletSnapshot
+    private var pendingCommands: [String: WalletCommand]
+    private var rejectedEvents: [WalletEvent] = []
+
+    public init(
+        baseURL: URL = APIConfiguration.productionBaseURL,
+        sessionStore: (any SessionStore)? = nil,
+        transport: any HTTPTransport = URLSessionTransport(),
+        cache: (any WalletSnapshotCache)? = nil,
+        pendingStore: (any PendingCommandStore)? = nil
+    ) {
+        self.baseURL = baseURL
+        self.sessionStore = sessionStore ?? KeychainSessionStore()
+        self.transport = transport
+        self.cache = cache ?? UserDefaultsWalletSnapshotCache()
+        self.pendingStore = pendingStore ?? (baseURL == APIConfiguration.productionBaseURL ? UserDefaultsPendingCommandStore() : InMemoryPendingCommandStore())
+        self.current = self.cache.load() ?? .empty()
+        self.pendingCommands = Dictionary(uniqueKeysWithValues: self.pendingStore.load().map { ($0.idempotencyKey, $0) })
+    }
+
+    public var isAuthenticated: Bool { sessionStore.session?.isExpired == false }
+
+    public func snapshot() -> WalletSnapshot {
+        snapshotWithPending()
+    }
+
+    public func authenticateApple(identityToken: String, nonce: String) async throws -> AuthSession {
+        guard !identityToken.isEmpty, !nonce.isEmpty else {
+            throw WalletAPIError.invalidResponse("Apple Sign In did not return the required identity proof.")
+        }
+        let body: [String: Any] = ["identityToken": identityToken, "nonce": nonce]
+        let data = try await request(path: "/v1/auth/apple", method: "POST", body: body, authenticated: false, idempotencyKey: nil)
+        let response = try decode(AuthResponseDTO.self, from: data)
+        guard !response.token.isEmpty, let expiresAt = parseTimestamp(response.expiresAt), expiresAt > .now else {
+            throw WalletAPIError.invalidResponse("The authentication service returned an invalid session.")
+        }
+        let session = AuthSession(token: response.token, expiresAt: expiresAt)
+        do {
+            try sessionStore.save(session)
+        } catch {
+            throw WalletAPIError.invalidResponse("The parent session could not be stored securely.")
+        }
+        return session
+    }
+
+    public func refresh(for role: UserRole) async throws -> WalletSnapshot {
+        guard isAuthenticated else { throw WalletAPIError.noSession }
+        try await flushPendingCommands()
+        do {
+            let path = role == .child ? "/v1/child-view" : "/v1/wallet"
+            let data = try await request(path: path, method: "GET", body: nil, authenticated: true, idempotencyKey: nil)
+            let response = try decode(SnapshotDTO.self, from: data)
+            if role == .child && response.readOnly != true {
+                throw WalletAPIError.invalidResponse("The child wallet response was not marked read-only.")
+            }
+            current = try mapSnapshot(response)
+            current.isStale = false
+            cache.save(current)
+            return snapshotWithPending()
+        } catch let error as WalletAPIError {
+            switch error {
+            case .network, .invalidResponse:
+                current.isStale = true
+                cache.save(current)
+            default:
+                break
+            }
+            throw error
+        }
+    }
+
+    public func activity(limit: Int = 50) async throws -> [WalletEvent] {
+        guard (1...100).contains(limit) else {
+            throw WalletAPIError.invalidResponse("Activity limit must be between 1 and 100.")
+        }
+        let data = try await request(path: "/v1/activity?limit=\(limit)", method: "GET", body: nil, authenticated: true, idempotencyKey: nil)
+        let response = try decode(ActivityListDTO.self, from: data)
+        guard response.virtualNotice == WalletVocabulary.virtualNotice else {
+            throw WalletAPIError.invalidResponse("The activity response did not contain the virtual-money notice.")
+        }
+        return try response.entries.map { try mapEntry($0, expected: nil) }
+    }
+
+    public func activityDetail(remoteID: String) async throws -> WalletEvent {
+        let data = try await request(path: "/v1/activity/\(pathComponent(remoteID))", method: "GET", body: nil, authenticated: true, idempotencyKey: nil)
+        let response = try decode(ActivityDetailDTO.self, from: data)
+        guard response.virtualNotice == WalletVocabulary.virtualNotice else {
+            throw WalletAPIError.invalidResponse("The activity detail did not contain the virtual-money notice.")
+        }
+        return try mapEntry(response.entry, expected: nil)
+    }
+
+    public func loanDetail(remoteID: String) async throws -> LoanDetail {
+        let data = try await request(path: "/v1/loans/\(pathComponent(remoteID))", method: "GET", body: nil, authenticated: true, idempotencyKey: nil)
+        let response = try decode(LoanDetailDTO.self, from: data)
+        guard response.virtualNotice == WalletVocabulary.virtualNotice else {
+            throw WalletAPIError.invalidResponse("The loan detail did not contain the virtual-money notice.")
+        }
+        return LoanDetail(loan: try mapLoan(response.loan), entries: try response.repaymentsAndLoanEntry.map { try mapEntry($0, expected: nil) })
+    }
+
+    public func setup(_ setup: ParentSetup) async throws -> WalletSnapshot {
+        var body: [String: Any] = [
+            "nickname": setup.nickname,
+            "lessonAgeBand": setup.lessonAgeBand
+        ]
+        if let familyName = setup.familyName { body["familyName"] = familyName }
+        if let avatarURL = setup.avatarURL { body["avatarUrl"] = avatarURL.absoluteString }
+        let data = try await request(path: "/v1/family/setup", method: "POST", body: body, authenticated: true, idempotencyKey: setup.idempotencyKey)
+        let response = try decode(SnapshotDTO.self, from: data)
+        current = try mapSnapshot(response)
+        current.isStale = false
+        cache.save(current)
+        return snapshotWithPending()
+    }
+
+    public func setAllowance(_ command: AllowanceRuleCommand) async throws -> WalletSnapshot {
+        var body: [String: Any] = [
+            "amountCents": command.amountCents,
+            "cadence": "weekly",
+            "weekday": command.weekday,
+            "startDate": formatDate(command.startDate)
+        ]
+        if let endDate = command.endDate { body["endDate"] = formatDate(endDate) }
+        let data = try await request(path: "/v1/allowance-rule", method: "PUT", body: body, authenticated: true, idempotencyKey: command.idempotencyKey)
+        let response = try decode(SnapshotDTO.self, from: data)
+        current = try mapSnapshot(response)
+        current.isStale = false
+        cache.save(current)
+        return snapshotWithPending()
+    }
+
+    public func submit(_ command: WalletCommand) async throws -> CommandResult {
+        guard isAuthenticated else { throw WalletAPIError.noSession }
+        do {
+            let result = try await sendCommand(command)
+            pendingCommands.removeValue(forKey: command.idempotencyKey)
+            savePendingCommands()
+            return result
+        } catch let error as WalletAPIError {
+            switch error {
+            case .unauthorized, .noSession:
+                throw error
+            case let .server(statusCode, _, message) where (400..<500).contains(statusCode):
+                pendingCommands.removeValue(forKey: command.idempotencyKey)
+                savePendingCommands()
+                let event = makeLocalEvent(for: command, state: .rejected, message: message, rejectionReason: message)
+                rejectedEvents.insert(event, at: 0)
+                return .rejected(event)
+            case .cancelled, .familyNotSetup:
+                throw error
+            case .server, .network, .invalidResponse, .invalidConfiguration:
+                pendingCommands[command.idempotencyKey] = command
+                savePendingCommands()
+                return .pending(makeLocalEvent(for: command, state: .pending, message: "This parent action is waiting to sync. It is not included in the accepted balance."))
+            }
+        }
+    }
+
+    public func clearSession() {
+        sessionStore.clear()
+        pendingCommands.removeAll()
+        rejectedEvents.removeAll()
+        pendingStore.clear()
+        current = .empty()
+        cache.clear()
+    }
+
+    private func flushPendingCommands() async throws {
+        guard !pendingCommands.isEmpty else { return }
+        for command in Array(pendingCommands.values) {
+            do {
+                _ = try await sendCommand(command)
+                pendingCommands.removeValue(forKey: command.idempotencyKey)
+                savePendingCommands()
+            } catch let error as WalletAPIError {
+                switch error {
+                case .unauthorized, .noSession:
+                    throw error
+                case let .server(statusCode, _, message) where (400..<500).contains(statusCode):
+                    pendingCommands.removeValue(forKey: command.idempotencyKey)
+                    rejectedEvents.insert(makeLocalEvent(for: command, state: .rejected, message: message, rejectionReason: message), at: 0)
+                    savePendingCommands()
+                default:
+                    continue
+                }
+            }
+        }
+    }
+
+    private func pathComponent(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? value
+    }
+
+    private func optionalBody(_ required: [String: Any], reason: String?) -> [String: Any] {
+        var body = required
+        if let reason { body["reason"] = reason }
+        return body
+    }
+
+    private func sendCommand(_ command: WalletCommand) async throws -> CommandResult {
+        let endpoint: (path: String, body: [String: Any])
+        switch command.kind {
+        case .deposit:
+            endpoint = ("/v1/wallet/deposits", optionalBody(["amountCents": command.amountCents], reason: command.reason))
+        case .withdrawal:
+            endpoint = ("/v1/wallet/withdrawals", optionalBody(["amountCents": command.amountCents], reason: command.reason))
+        case .loan:
+            var loanBody: [String: Any] = ["principalCents": command.amountCents]
+            if let purpose = command.reason { loanBody["purpose"] = purpose }
+            if let dueDate = command.dueDate { loanBody["dueDate"] = formatDate(dueDate) }
+            endpoint = ("/v1/loans", loanBody)
+        case .repayment:
+            guard let loanID = current.loan?.remoteID else {
+                throw WalletAPIError.server(statusCode: 409, code: "LOAN_NOT_FOUND", message: "There is no open loan to repay.")
+            }
+            endpoint = ("/v1/loans/\(loanID)/repayments", optionalBody(["amountCents": command.amountCents], reason: command.reason))
+        case .allowance:
+            guard let allowance = current.allowance,
+                  let ruleID = allowance.remoteID,
+                  let occurrenceID = allowance.nextOccurrenceID else {
+                throw WalletAPIError.server(statusCode: 409, code: "ALLOWANCE_NOT_SCHEDULED", message: "There is no scheduled allowance occurrence to record.")
+            }
+            endpoint = ("/v1/allowance-rule/\(ruleID)/occurrences/\(occurrenceID)/record", optionalBody([:], reason: command.reason))
+        }
+
+        let data = try await request(path: endpoint.path, method: "POST", body: endpoint.body, authenticated: true, idempotencyKey: command.idempotencyKey)
+        let response = try decode(CommandDTO.self, from: data)
+        let event = try mapEntry(response.entry, expected: command.kind)
+        guard response.wallet.balanceCents.value >= 0,
+              response.wallet.virtualNotice == WalletVocabulary.virtualNotice else {
+            throw WalletAPIError.invalidResponse("The command response did not contain an authoritative virtual wallet.")
+        }
+        current.acceptedBalanceCents = response.wallet.balanceCents.value
+        current.activities.removeAll { $0.remoteID == response.entry.id }
+        current.activities.insert(event, at: 0)
+        if let loan = response.loan {
+            current.loan = try mapLoan(loan)
+        } else if command.kind == .loan || command.kind == .repayment {
+            throw WalletAPIError.invalidResponse("The command response did not contain the updated loan.")
+        }
+        current.lastUpdated = event.date
+        current.isStale = false
+        cache.save(current)
+        return .accepted(event)
+    }
+
+    private func request(
+        path: String,
+        method: String,
+        body: [String: Any]?,
+        authenticated: Bool,
+        idempotencyKey: String?
+    ) async throws -> Data {
+        guard let url = URL(string: path, relativeTo: baseURL), url.scheme == "https" || baseURL.scheme == "http" else {
+            throw WalletAPIError.invalidConfiguration
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.timeoutInterval = 30
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let body {
+            guard JSONSerialization.isValidJSONObject(body), let data = try? JSONSerialization.data(withJSONObject: body) else {
+                throw WalletAPIError.invalidResponse("The request could not be encoded.")
+            }
+            request.httpBody = data
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        if let idempotencyKey {
+            request.setValue(idempotencyKey, forHTTPHeaderField: "Idempotency-Key")
+        }
+        if authenticated {
+            guard let session = sessionStore.session, !session.isExpired else {
+                sessionStore.clear()
+                throw WalletAPIError.unauthorized
+            }
+            request.setValue("Bearer \(session.token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await transport.data(for: request)
+        } catch {
+            throw WalletAPIError.network("The network is unavailable. The accepted balance was not changed.")
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw WalletAPIError.invalidResponse("The server returned an invalid HTTP response.")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            if http.statusCode == 401 {
+                sessionStore.clear()
+                throw WalletAPIError.unauthorized
+            }
+            if let envelope = try? JSONDecoder().decode(ErrorEnvelope.self, from: data) {
+                if envelope.error.code == "FAMILY_NOT_SETUP" { throw WalletAPIError.familyNotSetup }
+                throw WalletAPIError.server(statusCode: http.statusCode, code: envelope.error.code, message: envelope.error.message)
+            }
+            throw WalletAPIError.server(statusCode: http.statusCode, code: "HTTP_\(http.statusCode)", message: "The server did not accept this request.")
+        }
+        return data
+    }
+
+    private func mapSnapshot(_ response: SnapshotDTO) throws -> WalletSnapshot {
+        guard response.wallet.balanceCents.value >= 0,
+              response.wallet.virtualNotice == WalletVocabulary.virtualNotice else {
+            throw WalletAPIError.invalidResponse("The server returned an invalid virtual wallet.")
+        }
+        let activities = try response.recentActivity.map { try mapEntry($0, expected: nil) }
+        let latest = activities.map(\.date).max() ?? .now
+        return WalletSnapshot(
+            acceptedBalanceCents: response.wallet.balanceCents.value,
+            activities: activities,
+            loan: try response.loan.map(mapLoan),
+            allowance: try response.allowanceRule.map(mapAllowance),
+            pendingEvents: pendingEvents,
+            lastUpdated: latest,
+            isStale: false
+        )
+    }
+
+    private func mapEntry(_ entry: EntryDTO, expected: WalletCommandKind?) throws -> WalletEvent {
+        guard let type = activityType(entry.type), entry.amountCents.value > 0,
+              let date = parseTimestamp(entry.recordedAt), !entry.id.isEmpty else {
+            throw WalletAPIError.invalidResponse("The server returned an invalid activity entry.")
+        }
+        if let expected, commandKind(for: type) != expected {
+            throw WalletAPIError.invalidResponse("The server returned the wrong activity type.")
+        }
+        let expectedDirection = type == .withdrawal || type == .repayment ? "debit" : "credit"
+        guard entry.direction == expectedDirection else {
+            throw WalletAPIError.invalidResponse("The server returned an invalid activity direction.")
+        }
+        let amount = Money(cents: entry.amountCents.value).display
+        let explanation: String
+        switch type {
+        case .allowance: explanation = "Your parent added \(amount) virtual dollars as your allowance."
+        case .deposit: explanation = "Your parent added \(amount) virtual dollars to your wallet."
+        case .withdrawal: explanation = "Your parent recorded that \(amount) virtual dollars were used."
+        case .loan: explanation = "Your parent gave you \(amount) virtual dollars to use now and give back over time."
+        case .repayment: explanation = "Your parent recorded \(amount) virtual dollars returned toward the loan."
+        }
+        return WalletEvent(
+            id: UUID(uuidString: entry.id) ?? UUID(),
+            remoteID: entry.id,
+            type: type,
+            amountCents: entry.amountCents.value,
+            balanceBeforeCents: entry.balanceBeforeCents?.value,
+            balanceAfterCents: entry.balanceAfterCents?.value,
+            reason: entry.reason,
+            date: date,
+            syncState: .recorded,
+            explanation: explanation
+        )
+    }
+
+    private func mapLoan(_ loan: LoanDTO) throws -> Loan {
+        guard loan.principalCents.value > 0,
+              loan.outstandingCents.value >= 0,
+              loan.outstandingCents.value <= loan.principalCents.value,
+              loan.status == "open" || loan.status == "paid",
+              let createdAt = parseTimestamp(loan.createdAt) else {
+            throw WalletAPIError.invalidResponse("The server returned an invalid loan.")
+        }
+        _ = createdAt
+        return Loan(
+            remoteID: loan.id,
+            originalCents: loan.principalCents.value,
+            remainingCents: loan.outstandingCents.value,
+            purpose: loan.purpose,
+            dueDate: parseDate(loan.dueDate)
+        )
+    }
+
+    private func mapAllowance(_ allowance: AllowanceDTO) throws -> AllowancePlan {
+        guard allowance.amountCents.value > 0,
+              allowance.cadence == "weekly",
+              (0...6).contains(allowance.weekday),
+              let nextDate = parseDate(allowance.nextDueDate ?? allowance.startDate) else {
+            throw WalletAPIError.invalidResponse("The server returned an invalid allowance rule.")
+        }
+        return AllowancePlan(
+            remoteID: allowance.id,
+            amountCents: allowance.amountCents.value,
+            cadence: "every week",
+            weekday: allowance.weekday,
+            nextDate: nextDate,
+            endDate: parseDate(allowance.endDate),
+            nextOccurrenceID: allowance.nextOccurrenceId,
+            syncState: allowance.active ? .recorded : .rejected
+        )
+    }
+
+    private func savePendingCommands() {
+        pendingStore.save(Array(pendingCommands.values))
+    }
+
+    private var pendingEvents: [WalletEvent] {
+        pendingCommands.values.map { command in
+            makeLocalEvent(for: command, state: .pending, message: "This parent action is waiting to sync. It is not included in the accepted balance.")
+        }
+    }
+
+    private func snapshotWithPending() -> WalletSnapshot {
+        var result = current
+        result.pendingEvents = pendingEvents + rejectedEvents
+        return result
+    }
+
+    private func makeLocalEvent(for command: WalletCommand, state: SyncState, message: String, rejectionReason: String? = nil) -> WalletEvent {
+        let type: ActivityType = switch command.kind {
+        case .allowance: .allowance
+        case .deposit: .deposit
+        case .withdrawal: .withdrawal
+        case .loan: .loan
+        case .repayment: .repayment
+        }
+        return WalletEvent(
+            id: UUID(uuidString: command.idempotencyKey) ?? UUID(),
+            remoteID: command.idempotencyKey,
+            type: type,
+            amountCents: max(command.amountCents, 0),
+            reason: command.reason,
+            syncState: state,
+            explanation: message,
+            rejectionReason: rejectionReason
+        )
+    }
+
+    private func activityType(_ value: String) -> ActivityType? {
+        ActivityType(rawValue: value)
+    }
+
+    private func commandKind(for type: ActivityType) -> WalletCommandKind {
+        switch type {
+        case .allowance: .allowance
+        case .deposit: .deposit
+        case .withdrawal: .withdrawal
+        case .loan: .loan
+        case .repayment: .repayment
+        }
+    }
+
+    private func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        do {
+            return try JSONDecoder().decode(type, from: data)
+        } catch let error as WalletAPIError {
+            throw error
+        } catch {
+            throw WalletAPIError.invalidResponse("The server response could not be read.")
+        }
+    }
+
+    private func parseTimestamp(_ string: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: string) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: string)
+    }
+
+    private func parseDate(_ string: String?) -> Date? {
+        guard let string else { return nil }
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.date(from: string)
+    }
+
+    private func formatDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+}
+
+public enum AppleNonce {
+    public static func randomString(byteCount: Int = 32) throws -> String {
+        guard byteCount > 0 else { throw WalletAPIError.invalidResponse("Secure random generation failed.") }
+        var data = Data(count: byteCount)
+        let status = data.withUnsafeMutableBytes { buffer in
+            SecRandomCopyBytes(kSecRandomDefault, byteCount, buffer.baseAddress!)
+        }
+        guard status == errSecSuccess else { throw WalletAPIError.invalidResponse("Secure random generation failed.") }
+        return data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    public static func sha256(_ value: String) -> String {
+        let digest = SHA256.hash(data: Data(value.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/EddysWallet/Models/WalletAPI.swift
+++ b/EddysWallet/Models/WalletAPI.swift
@@ -5,8 +5,8 @@ import Security
 public enum APIConfiguration {
     /// The only shipped API environment. The backend operator must provision this
     /// host and TLS before a real-account simulator test can pass.
-    public static let productionBaseURL = URL(string: "https://api.eddyswallet.com")!
-    public static let productionBaseURLString = "https://api.eddyswallet.com"
+    public static let productionBaseURL = URL(string: "https://eddieswallet.kunchenguid.com")!
+    public static let productionBaseURLString = "https://eddieswallet.kunchenguid.com"
 }
 
 public enum WalletAPIError: Error, Equatable, LocalizedError {

--- a/EddysWallet/Models/WalletModels.swift
+++ b/EddysWallet/Models/WalletModels.swift
@@ -92,8 +92,11 @@ public struct Money: Hashable, Codable, Sendable, ExpressibleByIntegerLiteral {
 
 public struct WalletEvent: Identifiable, Hashable, Codable, Sendable {
     public let id: UUID
+    public let remoteID: String?
     public let type: ActivityType
     public let amountCents: Int
+    public let balanceBeforeCents: Int?
+    public let balanceAfterCents: Int?
     public let reason: String?
     public let date: Date
     public let syncState: SyncState
@@ -102,8 +105,11 @@ public struct WalletEvent: Identifiable, Hashable, Codable, Sendable {
 
     public init(
         id: UUID = UUID(),
+        remoteID: String? = nil,
         type: ActivityType,
         amountCents: Int,
+        balanceBeforeCents: Int? = nil,
+        balanceAfterCents: Int? = nil,
         reason: String? = nil,
         date: Date = .now,
         syncState: SyncState = .recorded,
@@ -111,8 +117,11 @@ public struct WalletEvent: Identifiable, Hashable, Codable, Sendable {
         rejectionReason: String? = nil
     ) {
         self.id = id
+        self.remoteID = remoteID
         self.type = type
         self.amountCents = amountCents
+        self.balanceBeforeCents = balanceBeforeCents
+        self.balanceAfterCents = balanceAfterCents
         self.reason = reason
         self.date = date
         self.syncState = syncState
@@ -134,12 +143,20 @@ public struct WalletEvent: Identifiable, Hashable, Codable, Sendable {
 }
 
 public struct Loan: Hashable, Codable, Sendable {
+    public let remoteID: String?
     public let originalCents: Int
     public var remainingCents: Int
     public let purpose: String?
     public let dueDate: Date?
 
-    public init(originalCents: Int, remainingCents: Int, purpose: String? = nil, dueDate: Date? = nil) {
+    public init(
+        remoteID: String? = nil,
+        originalCents: Int,
+        remainingCents: Int,
+        purpose: String? = nil,
+        dueDate: Date? = nil
+    ) {
+        self.remoteID = remoteID
         self.originalCents = originalCents
         self.remainingCents = remainingCents
         self.purpose = purpose
@@ -154,15 +171,32 @@ public struct Loan: Hashable, Codable, Sendable {
 }
 
 public struct AllowancePlan: Hashable, Codable, Sendable {
+    public let remoteID: String?
     public let amountCents: Int
     public let cadence: String
+    public let weekday: Int
     public let nextDate: Date
+    public let endDate: Date?
+    public let nextOccurrenceID: String?
     public let syncState: SyncState
 
-    public init(amountCents: Int, cadence: String, nextDate: Date, syncState: SyncState = .recorded) {
+    public init(
+        remoteID: String? = nil,
+        amountCents: Int,
+        cadence: String,
+        weekday: Int = 5,
+        nextDate: Date,
+        endDate: Date? = nil,
+        nextOccurrenceID: String? = nil,
+        syncState: SyncState = .recorded
+    ) {
+        self.remoteID = remoteID
         self.amountCents = amountCents
         self.cadence = cadence
+        self.weekday = weekday
         self.nextDate = nextDate
+        self.endDate = endDate
+        self.nextOccurrenceID = nextOccurrenceID
         self.syncState = syncState
     }
 }
@@ -194,6 +228,18 @@ public struct WalletSnapshot: Hashable, Codable, Sendable {
         self.isStale = isStale
     }
 
+    public static func empty(now: Date = .now) -> WalletSnapshot {
+        WalletSnapshot(
+            acceptedBalanceCents: 0,
+            activities: [],
+            loan: nil,
+            allowance: nil,
+            pendingEvents: [],
+            lastUpdated: now,
+            isStale: true
+        )
+    }
+
     public static func fixture(now: Date = .now) -> WalletSnapshot {
         let calendar = Calendar.current
         let loanDate = calendar.date(byAdding: .day, value: -8, to: now) ?? now
@@ -219,7 +265,7 @@ public struct WalletSnapshot: Hashable, Codable, Sendable {
     }
 }
 
-public enum WalletCommandKind: String, Sendable {
+public enum WalletCommandKind: String, Sendable, Codable {
     case allowance
     case deposit
     case withdrawal
@@ -227,17 +273,91 @@ public enum WalletCommandKind: String, Sendable {
     case repayment
 }
 
-public struct WalletCommand: Sendable {
+public struct WalletCommand: Sendable, Codable {
     public let kind: WalletCommandKind
     public let amountCents: Int
     public let reason: String?
     public let dueDate: Date?
+    public let idempotencyKey: String
 
-    public init(kind: WalletCommandKind, amountCents: Int, reason: String? = nil, dueDate: Date? = nil) {
+    public init(
+        kind: WalletCommandKind,
+        amountCents: Int,
+        reason: String? = nil,
+        dueDate: Date? = nil,
+        idempotencyKey: String = UUID().uuidString
+    ) {
         self.kind = kind
         self.amountCents = amountCents
         self.reason = reason
         self.dueDate = dueDate
+        self.idempotencyKey = idempotencyKey
+    }
+}
+
+public struct AllowanceRuleCommand: Sendable, Codable {
+    public let amountCents: Int
+    public let weekday: Int
+    public let startDate: Date
+    public let endDate: Date?
+    public let idempotencyKey: String
+
+    public init(
+        amountCents: Int,
+        weekday: Int,
+        startDate: Date,
+        endDate: Date? = nil,
+        idempotencyKey: String = UUID().uuidString
+    ) {
+        self.amountCents = amountCents
+        self.weekday = weekday
+        self.startDate = startDate
+        self.endDate = endDate
+        self.idempotencyKey = idempotencyKey
+    }
+}
+
+public struct ParentSetup: Sendable, Codable {
+    public let familyName: String?
+    public let nickname: String
+    public let lessonAgeBand: String
+    public let avatarURL: URL?
+    public let idempotencyKey: String
+
+    public init(
+        familyName: String? = nil,
+        nickname: String,
+        lessonAgeBand: String,
+        avatarURL: URL? = nil,
+        idempotencyKey: String = UUID().uuidString
+    ) {
+        self.familyName = familyName
+        self.nickname = nickname
+        self.lessonAgeBand = lessonAgeBand
+        self.avatarURL = avatarURL
+        self.idempotencyKey = idempotencyKey
+    }
+}
+
+public struct AuthSession: Codable, Hashable, Sendable {
+    public let token: String
+    public let expiresAt: Date
+
+    public init(token: String, expiresAt: Date) {
+        self.token = token
+        self.expiresAt = expiresAt
+    }
+
+    public var isExpired: Bool { expiresAt <= .now }
+}
+
+public struct LoanDetail: Sendable {
+    public let loan: Loan
+    public let entries: [WalletEvent]
+
+    public init(loan: Loan, entries: [WalletEvent]) {
+        self.loan = loan
+        self.entries = entries
     }
 }
 
@@ -249,8 +369,21 @@ public enum CommandResult: Sendable {
 
 @MainActor
 public protocol WalletRepository: AnyObject {
+    var isAuthenticated: Bool { get }
     func snapshot() -> WalletSnapshot
-    func submit(_ command: WalletCommand) -> CommandResult
+    func refresh(for role: UserRole) async throws -> WalletSnapshot
+    func activity(limit: Int) async throws -> [WalletEvent]
+    func activityDetail(remoteID: String) async throws -> WalletEvent
+    func loanDetail(remoteID: String) async throws -> LoanDetail
+    func submit(_ command: WalletCommand) async throws -> CommandResult
+    func setAllowance(_ command: AllowanceRuleCommand) async throws -> WalletSnapshot
+    func setup(_ setup: ParentSetup) async throws -> WalletSnapshot
+    func clearSession()
+}
+
+@MainActor
+public protocol ParentAuthenticator: AnyObject {
+    func authenticateApple(identityToken: String, nonce: String) async throws -> AuthSession
 }
 
 @MainActor
@@ -261,9 +394,44 @@ public final class MockWalletRepository: WalletRepository {
         self.current = snapshot
     }
 
+    public var isAuthenticated: Bool { true }
     public func snapshot() -> WalletSnapshot { current }
+    public func refresh(for _: UserRole) async throws -> WalletSnapshot { current }
+    public func activity(limit: Int) async throws -> [WalletEvent] { Array(current.activities.prefix(max(1, min(limit, 100)))) }
+    public func activityDetail(remoteID: String) async throws -> WalletEvent {
+        guard let event = current.activities.first(where: { $0.remoteID == remoteID }) else {
+            throw WalletAPIError.server(statusCode: 404, code: "ACTIVITY_NOT_FOUND", message: "The activity entry was not found.")
+        }
+        return event
+    }
+    public func loanDetail(remoteID: String) async throws -> LoanDetail {
+        guard let loan = current.loan, loan.remoteID == remoteID else {
+            throw WalletAPIError.server(statusCode: 404, code: "LOAN_NOT_FOUND", message: "The loan was not found.")
+        }
+        return LoanDetail(loan: loan, entries: current.activities.filter { $0.type == .loan || $0.type == .repayment })
+    }
+    public func clearSession() {}
 
-    public func submit(_ command: WalletCommand) -> CommandResult {
+    public func setup(_ setup: ParentSetup) async throws -> WalletSnapshot {
+        guard !setup.nickname.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return current }
+        return current
+    }
+
+    public func setAllowance(_ command: AllowanceRuleCommand) async throws -> WalletSnapshot {
+        guard command.amountCents > 0 else { return current }
+        current.allowance = AllowancePlan(
+            amountCents: command.amountCents,
+            cadence: "every week",
+            weekday: command.weekday,
+            nextDate: command.startDate,
+            endDate: command.endDate
+        )
+        current.lastUpdated = .now
+        current.isStale = false
+        return current
+    }
+
+    public func submit(_ command: WalletCommand) async throws -> CommandResult {
         guard command.amountCents > 0 else {
             return .rejected(makeEvent(for: command, state: .rejected, explanation: "This amount was not recorded.", rejectionReason: "Enter an amount greater than US$0.00."))
         }
@@ -293,7 +461,6 @@ public final class MockWalletRepository: WalletRepository {
             current.acceptedBalanceCents += command.amountCents
         case .allowance:
             current.acceptedBalanceCents += command.amountCents
-            current.allowance = AllowancePlan(amountCents: command.amountCents, cadence: "every Friday", nextDate: command.dueDate ?? .now)
         }
 
         let event = makeEvent(for: command, state: .recorded, explanation: explanation(for: command))

--- a/EddysWallet/Models/WalletStore.swift
+++ b/EddysWallet/Models/WalletStore.swift
@@ -5,32 +5,83 @@ import Foundation
 public final class WalletStore: ObservableObject {
     @Published public private(set) var snapshot: WalletSnapshot
     @Published public private(set) var role: UserRole = .parent
-    @Published public private(set) var isSignedIn = false
+    @Published public private(set) var isSignedIn: Bool
+    @Published public private(set) var needsSetup = false
+    @Published public private(set) var needsPINSetup = false
+    @Published public private(set) var isLoading = false
+    @Published public private(set) var isSigningIn = false
+    @Published public private(set) var errorMessage: String?
     @Published public var isShowingPinGate = false
     @Published public private(set) var pin = ""
     @Published public private(set) var pinError = false
 
     public let repository: any WalletRepository
-    private let parentPIN = "1234"
+    private let appleSignInCoordinator: AppleSignInCoordinator?
+    private let pinStore: any ParentPINStore
 
-    public init(repository: (any WalletRepository)? = nil) {
-        let resolvedRepository = repository ?? MockWalletRepository()
+    public init(
+        repository: (any WalletRepository)? = nil,
+        appleSignInCoordinator: AppleSignInCoordinator? = nil,
+        initiallySignedIn: Bool? = nil,
+        pinStore: (any ParentPINStore)? = nil
+    ) {
+        let resolvedRepository = repository ?? APIWalletRepository()
         self.repository = resolvedRepository
         self.snapshot = resolvedRepository.snapshot()
+        self.isSignedIn = initiallySignedIn ?? resolvedRepository.isAuthenticated
+        self.pinStore = pinStore ?? ((resolvedRepository is MockWalletRepository) ? InMemoryParentPINStore(pin: "1234") : KeychainParentPINStore())
+        if let appleSignInCoordinator {
+            self.appleSignInCoordinator = appleSignInCoordinator
+        } else if let authenticator = resolvedRepository as? any ParentAuthenticator {
+            self.appleSignInCoordinator = AppleSignInCoordinator(authenticator: authenticator)
+        } else {
+            self.appleSignInCoordinator = nil
+        }
+        self.needsPINSetup = self.isSignedIn && self.pinStore.pin == nil
+
+        if self.isSignedIn, !(resolvedRepository is MockWalletRepository) {
+            Task { [weak self] in await self?.refresh() }
+        }
     }
 
-    public func signInWithAppleIntegrationPoint() {
-        isSignedIn = true
+    public static func preview() -> WalletStore {
+        WalletStore(repository: MockWalletRepository(), initiallySignedIn: true, pinStore: InMemoryParentPINStore(pin: "1234"))
+    }
+
+    public func signInWithApple() async {
+        guard let appleSignInCoordinator else {
+            errorMessage = "Apple Sign In is unavailable in this build."
+            return
+        }
+        isSigningIn = true
+        errorMessage = nil
+        do {
+            _ = try await appleSignInCoordinator.signIn()
+            isSignedIn = true
+            await refresh()
+        } catch {
+            if case WalletAPIError.cancelled = error {
+                errorMessage = nil
+            } else {
+                errorMessage = userMessage(for: error)
+            }
+        }
+        isSigningIn = false
     }
 
     public func switchRole(to nextRole: UserRole) {
         guard nextRole != role else { return }
         if nextRole == .parent {
+            guard pinStore.pin != nil else {
+                needsPINSetup = true
+                return
+            }
             pin = ""
             pinError = false
             isShowingPinGate = true
         } else {
             role = .child
+            Task { [weak self] in await self?.refresh() }
         }
     }
 
@@ -39,10 +90,11 @@ public final class WalletStore: ObservableObject {
         pin.append(digit)
         pinError = false
         if pin.count == 4 {
-            if pin == parentPIN {
+            if pin == pinStore.pin {
                 role = .parent
                 isShowingPinGate = false
                 pin = ""
+                Task { [weak self] in await self?.refresh() }
             } else {
                 pinError = true
                 pin = ""
@@ -62,8 +114,87 @@ public final class WalletStore: ObservableObject {
         pinError = false
     }
 
+    public func refresh() async {
+        guard isSignedIn else { return }
+        isLoading = true
+        do {
+            snapshot = try await repository.refresh(for: role)
+            needsSetup = false
+            errorMessage = nil
+        } catch let error as WalletAPIError {
+            switch error {
+            case .familyNotSetup:
+                needsSetup = true
+                errorMessage = nil
+            case .unauthorized, .noSession:
+                signOut()
+                errorMessage = "Your parent session expired. Sign in with Apple again."
+            default:
+                errorMessage = userMessage(for: error)
+                snapshot = repository.snapshot()
+            }
+        } catch {
+            errorMessage = "The wallet could not be updated. Your last accepted balance is still shown."
+            snapshot = repository.snapshot()
+        }
+        isLoading = false
+    }
+
+    public func setupParent(_ setup: ParentSetup, pin: String, confirmation: String) async -> Bool {
+        guard pin.count == 4, pin.allSatisfy(\.isNumber), pin == confirmation else {
+            errorMessage = "Choose and confirm a four-digit parent PIN."
+            return false
+        }
+        isLoading = true
+        errorMessage = nil
+        do {
+            snapshot = try await repository.setup(setup)
+            try pinStore.save(pin: pin)
+            needsSetup = false
+            needsPINSetup = false
+            isSignedIn = true
+            isLoading = false
+            return true
+        } catch {
+            errorMessage = userMessage(for: error)
+            isLoading = false
+            return false
+        }
+    }
+
+    public func setParentPIN(_ pin: String, confirmation: String) -> Bool {
+        guard pin.count == 4, pin.allSatisfy(\.isNumber), pin == confirmation else {
+            errorMessage = "Choose and confirm a four-digit parent PIN."
+            return false
+        }
+        do {
+            try pinStore.save(pin: pin)
+            needsPINSetup = false
+            errorMessage = nil
+            return true
+        } catch {
+            errorMessage = userMessage(for: error)
+            return false
+        }
+    }
+
     @discardableResult
-    public func submit(_ command: WalletCommand) -> CommandResult {
+    public func setAllowance(_ command: AllowanceRuleCommand) async -> Bool {
+        isLoading = true
+        errorMessage = nil
+        do {
+            snapshot = try await repository.setAllowance(command)
+            isLoading = false
+            return true
+        } catch {
+            errorMessage = userMessage(for: error)
+            isLoading = false
+            return false
+        }
+    }
+
+    @discardableResult
+    public func submit(_ command: WalletCommand) async -> CommandResult {
         guard role == .parent else {
             let event = WalletEvent(
                 type: .deposit,
@@ -74,14 +205,59 @@ public final class WalletStore: ObservableObject {
             )
             return .rejected(event)
         }
-        let result = repository.submit(command)
-        snapshot = repository.snapshot()
-        return result
+        do {
+            let result = try await repository.submit(command)
+            snapshot = repository.snapshot()
+            return result
+        } catch let error as WalletAPIError {
+            if case .unauthorized = error { signOut() }
+            let event = WalletEvent(
+                type: activityType(for: command.kind),
+                amountCents: max(command.amountCents, 0),
+                reason: command.reason,
+                syncState: .rejected,
+                explanation: "This action was not recorded and did not change the accepted balance.",
+                rejectionReason: userMessage(for: error)
+            )
+            errorMessage = userMessage(for: error)
+            return .rejected(event)
+        } catch {
+            let event = WalletEvent(
+                type: activityType(for: command.kind),
+                amountCents: max(command.amountCents, 0),
+                reason: command.reason,
+                syncState: .rejected,
+                explanation: "This action was not recorded and did not change the accepted balance.",
+                rejectionReason: "The action could not be confirmed."
+            )
+            return .rejected(event)
+        }
     }
 
     public func signOut() {
+        repository.clearSession()
         isSignedIn = false
+        needsSetup = false
+        needsPINSetup = false
+        pinStore.clear()
         role = .parent
+        snapshot = .empty()
+        errorMessage = nil
         dismissPinGate()
+    }
+
+    private func userMessage(for error: Error) -> String {
+        if let apiError = error as? WalletAPIError { return apiError.localizedDescription }
+        return "The wallet could not complete that action. The accepted balance was not changed."
+    }
+
+    private func activityType(for kind: WalletCommandKind) -> ActivityType {
+        switch kind {
+        case .allowance: .allowance
+        case .deposit: .deposit
+        case .withdrawal: .withdrawal
+        case .loan: .loan
+        case .repayment: .repayment
+        }
     }
 }

--- a/EddysWallet/README.md
+++ b/EddysWallet/README.md
@@ -2,13 +2,40 @@
 
 `EddysWallet.xcodeproj` is a SwiftUI iOS/iPadOS app targeting iOS 17 and device families 1 and 2. The UI uses adaptive `horizontalSizeClass` layouts and native sheets, forms, navigation, Dynamic Type-friendly system fonts, and accessibility labels.
 
-## Local development
+## Production configuration
+
+The app has one shipped API environment. `APIConfiguration.productionBaseURL` is the explicit production base URL:
+
+```text
+https://api.eddyswallet.com
+```
+
+There is no staging or development API configuration in this client. The backend contract is the private service's `/v1` API: Apple session exchange, family setup, wallet and child-view reads, activity and loan details, weekly allowance rules and occurrences, deposits, withdrawals, loans, repayments, and required `Idempotency-Key` headers. `APIWalletRepository` is the concrete HTTP implementation behind `WalletRepository`; `MockWalletRepository` remains available for previews and unit tests.
+
+The opaque session token is stored with `KeychainSessionStore` using an after-first-unlock, this-device-only keychain item. Identity tokens and Apple private keys are not stored. A cached accepted snapshot is used for offline display and is marked stale when it cannot be refreshed. A command that has not received an authoritative accepted response is shown as **Waiting to sync** and does not change the accepted balance.
+
+## Local development and tests
 
 ```sh
 xcodebuild -project EddysWallet.xcodeproj -scheme EddysWallet \
   -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' test
 ```
 
-The app starts with fixture data after the local Sign in with Apple integration point. The fixture parent PIN is `1234` for the role-gate test path. No network call or private backend is used.
+Unit and contract-style transport tests cover Apple session exchange, bearer sessions, idempotency headers, authoritative virtual-money responses, pending network commands, expired sessions, and invalid responses. Tests inject `HTTPTransport` and `InMemorySessionStore`; they do not call the production service.
 
-`WalletRepository` is the boundary for a future authoritative API. `MockWalletRepository` is the only current implementation and keeps accepted balance, pending commands, rejected commands, stale time, and loan rules local to the fixture.
+## Manual simulator sequence
+
+This is the exact final-account test sequence. It has **not** been run to claim live end-to-end success because the production endpoint still needs to be available.
+
+1. In Apple Developer, confirm the explicit App ID `com.kunchenguid.eddyswallet` has Sign in with Apple enabled. In Xcode, select a locally configured signing team for the target; do not commit that Team ID.
+2. The service operator configures the single production host and TLS for `https://api.eddyswallet.com`, sets the backend Apple audience to `com.kunchenguid.eddyswallet`, and verifies `GET https://api.eddyswallet.com/healthz` is healthy. No Apple private key is needed by this native flow.
+3. Build and run the `EddysWallet` scheme on an iOS 17+ simulator with the app's registered bundle identifier. Sign in with Apple using the simulator's Apple ID/test account.
+4. Confirm the app reaches the parent setup form. Enter a nickname, lesson age band, and a four-digit parent PIN, create the wallet, and confirm that setup only appears as complete after the service accepts `POST /v1/family/setup`. The PIN is stored only in the platform keychain and gates parent mode locally.
+5. Confirm the parent wallet shows the accepted virtual balance and the fixed notice: “Virtual practice only. These dollars are pretend, cannot be redeemed, and never move real money.”
+6. Set the weekly allowance rule. Then record a deposit, an allowed withdrawal, a loan, a partial repayment, and a full repayment. For every action, verify the review screen, `Recorded` result, activity row, exact minor-unit balance, and the loan's remaining amount.
+7. Switch to Eddie's view. Entering child mode must refresh through `/v1/child-view`; confirm the view is read-only and contains no parent money actions. Confirm activity and loan details remain readable.
+8. Turn off network access, refresh, and confirm the last accepted snapshot says `Last updated`/stale. Submit a parent command and verify `Waiting to sync` without an accepted-balance change. Restore network, refresh, and verify the server accepts it once using its idempotency key or rejects it as `Not recorded` without changing accepted money.
+9. Expire or revoke the session on the service, make a request, and confirm the app clears the keychain session and returns to the Apple sign-in screen without displaying usable family data.
+10. Record the result as an operator test report. Do not mark this repository or pull request as live end-to-end verified until the real production endpoint and real-account simulator run are complete.
+
+Remaining operator configuration is intentionally outside this repository: Apple Developer capability/signing configuration, DNS and TLS for `api.eddyswallet.com`, backend `APPLE_AUDIENCES=com.kunchenguid.eddyswallet`, and the production service's backups, exports, and deployment health checks. No Team ID, token, credential, or private key belongs in Git.

--- a/EddysWallet/README.md
+++ b/EddysWallet/README.md
@@ -7,7 +7,7 @@
 The app has one shipped API environment. `APIConfiguration.productionBaseURL` is the explicit production base URL:
 
 ```text
-https://api.eddyswallet.com
+https://eddieswallet.kunchenguid.com
 ```
 
 There is no staging or development API configuration in this client. The backend contract is the private service's `/v1` API: Apple session exchange, family setup, wallet and child-view reads, activity and loan details, weekly allowance rules and occurrences, deposits, withdrawals, loans, repayments, and required `Idempotency-Key` headers. `APIWalletRepository` is the concrete HTTP implementation behind `WalletRepository`; `MockWalletRepository` remains available for previews and unit tests.
@@ -28,7 +28,7 @@ Unit and contract-style transport tests cover Apple session exchange, bearer ses
 This is the exact final-account test sequence. It has **not** been run to claim live end-to-end success because the production endpoint still needs to be available.
 
 1. In Apple Developer, confirm the explicit App ID `com.kunchenguid.eddyswallet` has Sign in with Apple enabled. In Xcode, select a locally configured signing team for the target; do not commit that Team ID.
-2. The service operator configures the single production host and TLS for `https://api.eddyswallet.com`, sets the backend Apple audience to `com.kunchenguid.eddyswallet`, and verifies `GET https://api.eddyswallet.com/healthz` is healthy. No Apple private key is needed by this native flow.
+2. The service operator configures the single production host and TLS for `https://eddieswallet.kunchenguid.com`, sets the backend Apple audience to `com.kunchenguid.eddyswallet`, and verifies `GET https://eddieswallet.kunchenguid.com/healthz` is healthy. No Apple private key is needed by this native flow.
 3. Build and run the `EddysWallet` scheme on an iOS 17+ simulator with the app's registered bundle identifier. Sign in with Apple using the simulator's Apple ID/test account.
 4. Confirm the app reaches the parent setup form. Enter a nickname, lesson age band, and a four-digit parent PIN, create the wallet, and confirm that setup only appears as complete after the service accepts `POST /v1/family/setup`. The PIN is stored only in the platform keychain and gates parent mode locally.
 5. Confirm the parent wallet shows the accepted virtual balance and the fixed notice: “Virtual practice only. These dollars are pretend, cannot be redeemed, and never move real money.”
@@ -38,4 +38,4 @@ This is the exact final-account test sequence. It has **not** been run to claim 
 9. Expire or revoke the session on the service, make a request, and confirm the app clears the keychain session and returns to the Apple sign-in screen without displaying usable family data.
 10. Record the result as an operator test report. Do not mark this repository or pull request as live end-to-end verified until the real production endpoint and real-account simulator run are complete.
 
-Remaining operator configuration is intentionally outside this repository: Apple Developer capability/signing configuration, DNS and TLS for `api.eddyswallet.com`, backend `APPLE_AUDIENCES=com.kunchenguid.eddyswallet`, and the production service's backups, exports, and deployment health checks. No Team ID, token, credential, or private key belongs in Git.
+Remaining operator configuration is intentionally outside this repository: Apple Developer capability/signing configuration, DNS and TLS for `eddieswallet.kunchenguid.com`, backend `APPLE_AUDIENCES=com.kunchenguid.eddyswallet`, and the production service's backups, exports, and deployment health checks. No Team ID, token, credential, or private key belongs in Git.

--- a/EddysWallet/Views/DetailViews.swift
+++ b/EddysWallet/Views/DetailViews.swift
@@ -29,6 +29,12 @@ struct ActivityDetailView: View {
                         detailRow(label: event.type == .loan ? "Purpose" : "Reason", value: reason)
                     }
                     detailRow(label: "Recorded by", value: "Parent")
+                    if let before = event.balanceBeforeCents, let after = event.balanceAfterCents {
+                        detailRow(
+                            label: "Accepted balance",
+                            value: "\(Money(cents: before).display) -> \(Money(cents: after).display)"
+                        )
+                    }
                     if let rejectionReason = event.rejectionReason {
                         detailRow(label: "Why", value: rejectionReason)
                             .foregroundStyle(EW.Color.red600)

--- a/EddysWallet/Views/FlowViews.swift
+++ b/EddysWallet/Views/FlowViews.swift
@@ -40,6 +40,7 @@ struct MoneyFlowView: View {
     @State private var step: Step = .amount
     @State private var resultState: SyncState?
     @State private var resultMessage = ""
+    @State private var isSubmitting = false
 
     private enum Step { case amount, review, result }
 
@@ -183,9 +184,11 @@ struct MoneyFlowView: View {
                     .background(EW.Color.cardAlt, in: RoundedRectangle(cornerRadius: EW.Radius.medium, style: .continuous))
 
                 Button("Confirm \(kind.title.lowercased())") {
-                    confirm()
+                    Task { await confirm() }
                 }
                 .buttonStyle(PrimaryButtonStyle())
+                .disabled(isSubmitting)
+                .opacity(isSubmitting ? 0.45 : 1)
                 Button("Back") { step = .amount }
                     .buttonStyle(SecondaryButtonStyle(compact: true))
             }
@@ -240,15 +243,16 @@ struct MoneyFlowView: View {
         }
     }
 
-    private func confirm() {
-        guard let cents = parsedCents else { return }
+    private func confirm() async {
+        guard let cents = parsedCents, !isSubmitting else { return }
+        isSubmitting = true
         let command = WalletCommand(
             kind: kind.commandKind,
             amountCents: cents,
             reason: reason.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : reason,
             dueDate: kind == .loan ? dueDate : nil
         )
-        let result = store.submit(command)
+        let result = await store.submit(command)
         switch result {
         case .accepted:
             resultState = .recorded
@@ -260,6 +264,7 @@ struct MoneyFlowView: View {
             resultState = .rejected
             resultMessage = event.rejectionReason ?? "This action was not recorded and did not change the accepted balance."
         }
+        isSubmitting = false
         step = .result
     }
 }
@@ -272,6 +277,7 @@ struct AllowanceView: View {
     @State private var showDraft = false
     @State private var showReview = false
     @State private var resultState: SyncState?
+    @State private var resultMessage = ""
 
     var body: some View {
         NavigationStack {
@@ -308,6 +314,11 @@ struct AllowanceView: View {
                     }
                     if let resultState {
                         StatusPill(state: resultState)
+                        if !resultMessage.isEmpty {
+                            Text(resultMessage)
+                                .font(EW.Font.caption)
+                                .foregroundStyle(EW.Color.textSecondary)
+                        }
                     }
 
                     Button("Review allowance") { showReview = true }
@@ -329,9 +340,18 @@ struct AllowanceView: View {
             }
             .sheet(isPresented: $showReview) {
                 AllowanceReviewView(amountCents: Money.parse(amount)?.cents ?? 0, startDate: startDate) {
-                    let command = WalletCommand(kind: .allowance, amountCents: Money.parse(amount)?.cents ?? 0, reason: "Weekly", dueDate: startDate)
-                    _ = store.submit(command)
-                    resultState = .recorded
+                    let calendar = Calendar(identifier: .gregorian)
+                    let weekday = calendar.component(.weekday, from: startDate) - 1
+                    let command = AllowanceRuleCommand(
+                        amountCents: Money.parse(amount)?.cents ?? 0,
+                        weekday: weekday,
+                        startDate: startDate
+                    )
+                    let accepted = await store.setAllowance(command)
+                    resultState = accepted ? .recorded : .rejected
+                    resultMessage = accepted
+                        ? "The weekly allowance plan was recorded. Its next occurrence is separate from an allowance event until your parent records it."
+                        : (store.errorMessage ?? "The allowance plan was not recorded.")
                     showReview = false
                     showDraft = false
                 }
@@ -345,22 +365,24 @@ private struct AllowanceReviewView: View {
     @Environment(\.dismiss) private var dismiss
     let amountCents: Int
     let startDate: Date
-    let confirm: () -> Void
+    let confirm: () async -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: EW.Space.five) {
             Text("Review allowance")
                 .font(EW.Font.heading)
                 .foregroundStyle(EW.Color.textPrimary)
-            Text("Add \(Money(cents: amountCents).display) virtual dollars every Friday starting \(startDate.formatted(.dateTime.month(.abbreviated).day())).")
+            Text("Add \(Money(cents: amountCents).display) virtual dollars each week starting \(startDate.formatted(.dateTime.month(.abbreviated).day())).")
                 .font(EW.Font.body)
                 .foregroundStyle(EW.Color.textSecondary)
             Text("This creates a plan for future occurrences. The plan is not an allowance event until it is accepted.")
                 .font(EW.Font.caption)
                 .foregroundStyle(EW.Color.textTertiary)
             Button("Confirm allowance") {
-                confirm()
-                dismiss()
+                Task {
+                    await confirm()
+                    dismiss()
+                }
             }
             .buttonStyle(PrimaryButtonStyle())
             Button("Back") { dismiss() }
@@ -443,5 +465,5 @@ struct PinGateView: View {
 }
 
 #Preview("Deposit flow") {
-    MoneyFlowView(kind: .deposit).environmentObject(WalletStore())
+    MoneyFlowView(kind: .deposit).environmentObject(WalletStore.preview())
 }

--- a/EddysWallet/Views/ParentPINSetupView.swift
+++ b/EddysWallet/Views/ParentPINSetupView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct ParentPINSetupView: View {
+    @EnvironmentObject private var store: WalletStore
+    @State private var pin = ""
+    @State private var confirmation = ""
+
+    var body: some View {
+        ZStack {
+            EW.Color.appBackground.ignoresSafeArea()
+            VStack(alignment: .leading, spacing: EW.Space.five) {
+                Image(systemName: "lock.shield")
+                    .font(.system(size: 42))
+                    .foregroundStyle(EW.Color.primaryActive)
+                Text("Set a parent PIN")
+                    .font(EW.Font.display)
+                    .foregroundStyle(EW.Color.textPrimary)
+                Text("This PIN protects parent mode on this iPad. It does not grant service permissions or create a child login.")
+                    .font(EW.Font.body)
+                    .foregroundStyle(EW.Color.textSecondary)
+                SecureField("Four digits", text: $pin)
+                    .keyboardType(.numberPad)
+                    .textFieldStyle(.roundedBorder)
+                    .onChange(of: pin) { _, value in pin = String(value.filter(\.isNumber).prefix(4)) }
+                SecureField("Confirm PIN", text: $confirmation)
+                    .keyboardType(.numberPad)
+                    .textFieldStyle(.roundedBorder)
+                    .onChange(of: confirmation) { _, value in confirmation = String(value.filter(\.isNumber).prefix(4)) }
+                if let errorMessage = store.errorMessage {
+                    Text(errorMessage)
+                        .font(EW.Font.caption)
+                        .foregroundStyle(EW.Color.red600)
+                }
+                Button("Save parent PIN") {
+                    _ = store.setParentPIN(pin, confirmation: confirmation)
+                }
+                .buttonStyle(PrimaryButtonStyle())
+                .disabled(pin.count != 4 || pin != confirmation)
+                .opacity(pin.count != 4 || pin != confirmation ? 0.45 : 1)
+                Button("Sign out") { store.signOut() }
+                    .buttonStyle(SecondaryButtonStyle(compact: true))
+            }
+            .padding(EW.Space.screenMargin)
+            .frame(maxWidth: 620)
+        }
+    }
+}
+
+#Preview("Parent PIN") {
+    ParentPINSetupView().environmentObject(WalletStore.preview())
+}

--- a/EddysWallet/Views/SetupView.swift
+++ b/EddysWallet/Views/SetupView.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+struct SetupView: View {
+    @EnvironmentObject private var store: WalletStore
+    @State private var nickname = "Eddie"
+    @State private var familyName = ""
+    @State private var ageBand = "school-age"
+    @State private var pin = ""
+    @State private var confirmationPIN = ""
+
+    private let ageBands = [
+        (id: "early-years", title: "Early years"),
+        (id: "school-age", title: "School age"),
+        (id: "teen", title: "Teen")
+    ]
+
+    var body: some View {
+        ZStack {
+            EW.Color.appBackground.ignoresSafeArea()
+            ScrollView {
+                VStack(alignment: .leading, spacing: EW.Space.six) {
+                    VStack(alignment: .leading, spacing: EW.Space.two) {
+                        Text("Set up Eddie's wallet")
+                            .font(EW.Font.display)
+                            .foregroundStyle(EW.Color.textPrimary)
+                        Text("Create one parent-managed child profile. No child login or Apple identity is needed.")
+                            .font(EW.Font.body)
+                            .foregroundStyle(EW.Color.textSecondary)
+                    }
+
+                    VStack(alignment: .leading, spacing: EW.Space.four) {
+                        field(title: "Eddie's nickname", text: $nickname, placeholder: "Eddie")
+                        field(title: "Family name (optional)", text: $familyName, placeholder: "Eddie's family")
+                        VStack(alignment: .leading, spacing: EW.Space.two) {
+                            Text("Lesson age band")
+                                .font(EW.Font.captionUpper)
+                                .foregroundStyle(EW.Color.textTertiary)
+                            Picker("Lesson age band", selection: $ageBand) {
+                                ForEach(ageBands, id: \.id) { band in
+                                    Text(band.title).tag(band.id)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, EW.Space.four)
+                            .frame(minHeight: 52)
+                            .background(EW.Color.card, in: RoundedRectangle(cornerRadius: EW.Radius.medium, style: .continuous))
+                            .overlay {
+                                RoundedRectangle(cornerRadius: EW.Radius.medium, style: .continuous)
+                                    .stroke(EW.Color.border, lineWidth: 1)
+                            }
+                        }
+                        VStack(alignment: .leading, spacing: EW.Space.two) {
+                            Text("Parent PIN")
+                                .font(EW.Font.captionUpper)
+                                .foregroundStyle(EW.Color.textTertiary)
+                            Text("This four-digit PIN protects parent mode on this iPad.")
+                                .font(EW.Font.caption)
+                                .foregroundStyle(EW.Color.textSecondary)
+                            SecureField("Four digits", text: $pin)
+                                .keyboardType(.numberPad)
+                                .textFieldStyle(.roundedBorder)
+                                .onChange(of: pin) { _, value in pin = String(value.filter(\.isNumber).prefix(4)) }
+                            SecureField("Confirm PIN", text: $confirmationPIN)
+                                .keyboardType(.numberPad)
+                                .textFieldStyle(.roundedBorder)
+                                .onChange(of: confirmationPIN) { _, value in confirmationPIN = String(value.filter(\.isNumber).prefix(4)) }
+                        }
+                    }
+                    .ewCard()
+
+                    Text("This creates the family and wallet on the authoritative service. If the request fails, this form remains a local draft and no wallet is claimed to be saved.")
+                        .font(EW.Font.caption)
+                        .foregroundStyle(EW.Color.textTertiary)
+
+                    if let errorMessage = store.errorMessage {
+                        Text(errorMessage)
+                            .font(EW.Font.caption)
+                            .foregroundStyle(EW.Color.red600)
+                    }
+
+                    Button {
+                        Task {
+                            let setup = ParentSetup(
+                                familyName: familyName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : familyName,
+                                nickname: nickname.trimmingCharacters(in: .whitespacesAndNewlines),
+                                lessonAgeBand: ageBand
+                            )
+                            _ = await store.setupParent(setup, pin: pin, confirmation: confirmationPIN)
+                        }
+                    } label: {
+                        if store.isLoading {
+                            ProgressView()
+                                .frame(maxWidth: .infinity, minHeight: 52)
+                        } else {
+                            Text("Create Eddie's wallet")
+                                .frame(maxWidth: .infinity, minHeight: 52)
+                        }
+                    }
+                    .buttonStyle(PrimaryButtonStyle())
+                    .disabled(store.isLoading || nickname.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || pin.count != 4 || pin != confirmationPIN)
+                    .opacity(store.isLoading || nickname.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || pin.count != 4 || pin != confirmationPIN ? 0.45 : 1)
+
+                    Button("Sign out") { store.signOut() }
+                        .buttonStyle(SecondaryButtonStyle(compact: true))
+                }
+                .padding(EW.Space.screenMargin)
+                .frame(maxWidth: 620)
+                .frame(maxWidth: .infinity, alignment: .center)
+            }
+        }
+    }
+
+    private func field(title: String, text: Binding<String>, placeholder: String) -> some View {
+        VStack(alignment: .leading, spacing: EW.Space.two) {
+            Text(title)
+                .font(EW.Font.captionUpper)
+                .foregroundStyle(EW.Color.textTertiary)
+            TextField(placeholder, text: text)
+                .font(EW.Font.body)
+                .textFieldStyle(.roundedBorder)
+        }
+    }
+}
+
+#Preview("Setup") {
+    SetupView().environmentObject(WalletStore.preview())
+}

--- a/EddysWallet/Views/WalletView.swift
+++ b/EddysWallet/Views/WalletView.swift
@@ -20,6 +20,14 @@ struct WalletView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: EW.Space.six) {
                     roleSwitcher
+                    if let errorMessage = store.errorMessage {
+                        Label(errorMessage, systemImage: "exclamationmark.triangle")
+                            .font(EW.Font.caption)
+                            .foregroundStyle(EW.Color.red600)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(EW.Space.three)
+                            .background(EW.Color.dangerTint, in: RoundedRectangle(cornerRadius: EW.Radius.medium, style: .continuous))
+                    }
                     if store.role == .parent {
                         parentWallet
                     } else {
@@ -48,6 +56,12 @@ struct WalletView: View {
                     .accessibilityLabel("Wallet menu")
                 }
             }
+        }
+        .task(id: store.role) {
+            await store.refresh()
+        }
+        .refreshable {
+            await store.refresh()
         }
         .sheet(item: $selectedEvent) { event in
             ActivityDetailView(event: event)
@@ -450,11 +464,11 @@ private struct LoanCardView: View {
 }
 
 #Preview("Parent wallet") {
-    WalletView().environmentObject(WalletStore())
+    WalletView().environmentObject(WalletStore.preview())
 }
 
 #Preview("Child wallet") {
-    let store = WalletStore()
+    let store = WalletStore.preview()
     store.switchRole(to: .child)
     return WalletView().environmentObject(store)
 }

--- a/EddysWallet/Views/WelcomeView.swift
+++ b/EddysWallet/Views/WelcomeView.swift
@@ -39,13 +39,26 @@ struct WelcomeView: View {
 
                     VStack(spacing: EW.Space.three) {
                         Button {
-                            // This is deliberately a local integration point. Real AuthenticationServices wiring is future scope.
-                            store.signInWithAppleIntegrationPoint()
+                            Task { await store.signInWithApple() }
                         } label: {
-                            Label("Sign in with Apple", systemImage: "apple.logo")
+                            if store.isSigningIn {
+                                ProgressView()
+                                    .tint(.white)
+                                    .frame(maxWidth: .infinity, minHeight: 52)
+                            } else {
+                                Label("Sign in with Apple", systemImage: "apple.logo")
+                            }
                         }
                         .buttonStyle(AppleSignInButtonStyle())
-                        .accessibilityHint("Parent sign-in integration point")
+                        .disabled(store.isSigningIn)
+                        .accessibilityHint("Parent sign-in only. Eddie does not need an account.")
+
+                        if let errorMessage = store.errorMessage {
+                            Text(errorMessage)
+                                .font(EW.Font.caption)
+                                .foregroundStyle(EW.Color.red600)
+                                .multilineTextAlignment(.center)
+                        }
 
                         Text("Parent sign-in only. Eddie does not need an account.")
                             .font(EW.Font.caption)

--- a/EddysWalletTests/APIRepositoryTests.swift
+++ b/EddysWalletTests/APIRepositoryTests.swift
@@ -1,0 +1,201 @@
+import Foundation
+import XCTest
+@testable import EddysWallet
+
+@MainActor
+final class APIRepositoryTests: XCTestCase {
+    func testAppleSessionRequestUsesIdentityTokenAndNonceAndStoresOpaqueSession() async throws {
+        let transport = StubHTTPTransport(responses: [
+            StubHTTPTransport.Response(
+                statusCode: 201,
+                body: Data(#"{"token":"opaque-session","expiresAt":"2099-01-01T00:00:00Z","parent":{"provider":"apple","subject":"apple-subject","email":null}}"#.utf8)
+            )
+        ])
+        let sessions = InMemorySessionStore()
+        let repository = APIWalletRepository(
+            baseURL: URL(string: "https://api.example.test")!,
+            sessionStore: sessions,
+            transport: transport,
+            cache: TestSnapshotCache()
+        )
+
+        let session = try await repository.authenticateApple(identityToken: "native.identity.token", nonce: "signed-nonce")
+
+        XCTAssertEqual(session.token, "opaque-session")
+        XCTAssertEqual(sessions.session?.token, "opaque-session")
+        XCTAssertEqual(transport.requests.count, 1)
+        guard let request = transport.requests.first else { return XCTFail("The authentication request was not sent") }
+        XCTAssertEqual(request.url?.absoluteString, "https://api.example.test/v1/auth/apple")
+        XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+        guard let bodyData = request.httpBody else { return XCTFail("The authentication request had no body") }
+        let body = try bodyData.jsonObject()
+        XCTAssertEqual(body["identityToken"] as? String, "native.identity.token")
+        XCTAssertEqual(body["nonce"] as? String, "signed-nonce")
+    }
+
+    func testDepositUsesIdempotencyKeyAndOnlyAcceptedResponseChangesBalance() async throws {
+        let entryID = "11111111-1111-1111-1111-111111111111"
+        let transport = StubHTTPTransport(responses: [
+            StubHTTPTransport.Response(statusCode: 200, body: snapshotBody(balance: 0)),
+            StubHTTPTransport.Response(
+                statusCode: 201,
+                body: Data(#"{"entry":{"id":"11111111-1111-1111-1111-111111111111","type":"deposit","direction":"credit","amountCents":150,"balanceBeforeCents":0,"balanceAfterCents":150,"reason":"first","loanId":null,"recordedBy":"parent","recordedAt":"2099-01-01T00:00:00Z"},"wallet":{"id":"wallet","currency":"USD","balanceCents":150,"virtualNotice":"Virtual practice only. These dollars are pretend, cannot be redeemed, and never move real money."}}"#.utf8)
+            )
+        ])
+        let repository = APIWalletRepository(
+            baseURL: URL(string: "https://api.example.test")!,
+            sessionStore: InMemorySessionStore(session: validSession),
+            transport: transport,
+            cache: TestSnapshotCache()
+        )
+
+        _ = try await repository.refresh(for: .parent)
+        let result = try await repository.submit(WalletCommand(kind: .deposit, amountCents: 150, reason: "first", idempotencyKey: "deposit-key"))
+
+        guard case .accepted(let event) = result else { return XCTFail("The accepted response must be recorded") }
+        XCTAssertEqual(event.remoteID, entryID)
+        XCTAssertEqual(repository.snapshot().acceptedBalanceCents, 150)
+        XCTAssertEqual(repository.snapshot().activities.first?.amountCents, 150)
+        let post = try XCTUnwrap(transport.requests.last)
+        XCTAssertEqual(post.httpMethod, "POST")
+        XCTAssertEqual(post.value(forHTTPHeaderField: "Idempotency-Key"), "deposit-key")
+        XCTAssertEqual(post.url?.path, "/v1/wallet/deposits")
+    }
+
+    func testNetworkFailureReturnsWaitingToSyncAndDoesNotChangeAcceptedBalance() async throws {
+        let transport = StubHTTPTransport(error: URLError(.notConnectedToInternet))
+        let repository = APIWalletRepository(
+            baseURL: URL(string: "https://api.example.test")!,
+            sessionStore: InMemorySessionStore(session: validSession),
+            transport: transport,
+            cache: TestSnapshotCache()
+        )
+        _ = try? await repository.refresh(for: .parent)
+
+        let result = try await repository.submit(WalletCommand(kind: .withdrawal, amountCents: 50, idempotencyKey: "offline-key"))
+
+        guard case .pending(let event) = result else { return XCTFail("A network failure must remain pending") }
+        XCTAssertEqual(event.syncState, .pending)
+        XCTAssertEqual(repository.snapshot().acceptedBalanceCents, 0)
+        XCTAssertEqual(repository.snapshot().pendingEvents.count, 1)
+    }
+
+    func testExpiredSessionIsClearedOnUnauthorizedResponse() async throws {
+        let transport = StubHTTPTransport(responses: [StubHTTPTransport.Response(statusCode: 401, body: Data(#"{"error":{"code":"UNAUTHENTICATED","message":"expired"}}"#.utf8))])
+        let sessions = InMemorySessionStore(session: validSession)
+        let repository = APIWalletRepository(
+            baseURL: URL(string: "https://api.example.test")!,
+            sessionStore: sessions,
+            transport: transport,
+            cache: TestSnapshotCache()
+        )
+
+        do {
+            _ = try await repository.refresh(for: .parent)
+            XCTFail("Unauthorized responses must fail")
+        } catch let error as WalletAPIError {
+            XCTAssertEqual(error, .unauthorized)
+        }
+        XCTAssertNil(sessions.session)
+        XCTAssertFalse(repository.isAuthenticated)
+    }
+
+    func testChildRefreshRequiresServerReadOnlyResponse() async throws {
+        let body = Data("""
+        {
+          "wallet": {"id":"wallet","currency":"USD","balanceCents":0,"virtualNotice":"Virtual practice only. These dollars are pretend, cannot be redeemed, and never move real money."},
+          "allowanceRule": null,
+          "loan": null,
+          "recentActivity": [],
+          "readOnly": false
+        }
+        """.utf8)
+        let repository = APIWalletRepository(
+            baseURL: URL(string: "https://api.example.test")!,
+            sessionStore: InMemorySessionStore(session: validSession),
+            transport: StubHTTPTransport(responses: [StubHTTPTransport.Response(statusCode: 200, body: body)]),
+            cache: TestSnapshotCache()
+        )
+
+        do {
+            _ = try await repository.refresh(for: .child)
+            XCTFail("The client must reject a child response without a server read-only marker")
+        } catch let error as WalletAPIError {
+            guard case .invalidResponse = error else { return XCTFail("Expected an invalid response error") }
+        }
+    }
+
+    func testInvalidVirtualNoticeCannotBecomeAnAcceptedSnapshot() async throws {
+        let invalid = Data(#"{"wallet":{"id":"wallet","currency":"USD","balanceCents":999,"virtualNotice":"US dollars"},"allowanceRule":null,"loan":null,"recentActivity":[]}"#.utf8)
+        let repository = APIWalletRepository(
+            baseURL: URL(string: "https://api.example.test")!,
+            sessionStore: InMemorySessionStore(session: validSession),
+            transport: StubHTTPTransport(responses: [StubHTTPTransport.Response(statusCode: 200, body: invalid)]),
+            cache: TestSnapshotCache()
+        )
+
+        do {
+            _ = try await repository.refresh(for: .parent)
+            XCTFail("An invalid authoritative response must fail")
+        } catch let error as WalletAPIError {
+            guard case .invalidResponse = error else { return XCTFail("Expected an invalid response error") }
+        }
+        XCTAssertEqual(repository.snapshot().acceptedBalanceCents, 0)
+    }
+
+    private var validSession: AuthSession {
+        AuthSession(token: "opaque-session", expiresAt: Date(timeIntervalSince1970: 4_000_000_000))
+    }
+
+    private func snapshotBody(balance: Int) -> Data {
+        Data("""
+        {
+          "family": {"id":"family","name":"Eddie's family"},
+          "child": {"id":"child","nickname":"Eddie","avatarUrl":null,"lessonAgeBand":"school-age"},
+          "wallet": {"id":"wallet","currency":"USD","balanceCents":\(balance),"virtualNotice":"Virtual practice only. These dollars are pretend, cannot be redeemed, and never move real money."},
+          "allowanceRule": null,
+          "loan": null,
+          "recentActivity": []
+        }
+        """.utf8)
+    }
+}
+
+private final class StubHTTPTransport: HTTPTransport {
+    struct Response {
+        let statusCode: Int
+        let body: Data
+    }
+
+    var responses: [Response]
+    var requests: [URLRequest] = []
+    let error: Error?
+
+    init(responses: [Response] = [], error: Error? = nil) {
+        self.responses = responses
+        self.error = error
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        requests.append(request)
+        if let error { throw error }
+        guard !responses.isEmpty else { throw URLError(.badServerResponse) }
+        let response = responses.removeFirst()
+        let http = HTTPURLResponse(url: request.url!, statusCode: response.statusCode, httpVersion: nil, headerFields: nil)!
+        return (response.body, http)
+    }
+}
+
+@MainActor
+private final class TestSnapshotCache: WalletSnapshotCache {
+    var value: WalletSnapshot?
+    func load() -> WalletSnapshot? { value }
+    func save(_ snapshot: WalletSnapshot) { value = snapshot }
+    func clear() { value = nil }
+}
+
+private extension Data {
+    func jsonObject() throws -> [String: Any] {
+        try XCTUnwrap(JSONSerialization.jsonObject(with: self) as? [String: Any])
+    }
+}

--- a/EddysWalletTests/APIRepositoryTests.swift
+++ b/EddysWalletTests/APIRepositoryTests.swift
@@ -4,6 +4,11 @@ import XCTest
 
 @MainActor
 final class APIRepositoryTests: XCTestCase {
+    func testProductionConfigurationShipsTheRealBackendURL() {
+        XCTAssertEqual(APIConfiguration.productionBaseURLString, "https://eddieswallet.kunchenguid.com")
+        XCTAssertEqual(APIConfiguration.productionBaseURL.absoluteString, "https://eddieswallet.kunchenguid.com")
+    }
+
     func testAppleSessionRequestUsesIdentityTokenAndNonceAndStoresOpaqueSession() async throws {
         let transport = StubHTTPTransport(responses: [
             StubHTTPTransport.Response(

--- a/EddysWalletTests/WalletTests.swift
+++ b/EddysWalletTests/WalletTests.swift
@@ -21,12 +21,27 @@ final class WalletTests: XCTestCase {
         XCTAssertFalse(store.isShowingPinGate)
     }
 
-    func testChildModeCannotSubmitParentMoneyCommand() {
+    func testParentPINMustBeConfirmedBeforeParentMode() {
+        let pinStore = InMemoryParentPINStore()
+        let store = WalletStore(
+            repository: MockWalletRepository(snapshot: .fixture()),
+            initiallySignedIn: true,
+            pinStore: pinStore
+        )
+        XCTAssertTrue(store.needsPINSetup)
+        XCTAssertFalse(store.setParentPIN("1234", confirmation: "1235"))
+        XCTAssertTrue(store.needsPINSetup)
+        XCTAssertTrue(store.setParentPIN("1234", confirmation: "1234"))
+        XCTAssertFalse(store.needsPINSetup)
+        XCTAssertEqual(pinStore.pin, "1234")
+    }
+
+    func testChildModeCannotSubmitParentMoneyCommand() async {
         let store = WalletStore(repository: MockWalletRepository(snapshot: .fixture()))
         let originalBalance = store.snapshot.acceptedBalanceCents
         store.switchRole(to: .child)
 
-        let result = store.submit(WalletCommand(kind: .deposit, amountCents: 1_000))
+        let result = await store.submit(WalletCommand(kind: .deposit, amountCents: 1_000))
         guard case .rejected(let event) = result else {
             return XCTFail("Child mode must reject money commands")
         }
@@ -55,10 +70,10 @@ final class WalletTests: XCTestCase {
         XCTAssertTrue(fixture.pendingEvents.contains { $0.syncState == .rejected })
     }
 
-    func testRejectedWithdrawalDoesNotChangeAcceptedBalance() {
+    func testRejectedWithdrawalDoesNotChangeAcceptedBalance() async {
         let repository = MockWalletRepository(snapshot: .fixture())
         let before = repository.snapshot().acceptedBalanceCents
-        let result = repository.submit(WalletCommand(kind: .withdrawal, amountCents: before + 1))
+        let result = try! await repository.submit(WalletCommand(kind: .withdrawal, amountCents: before + 1))
 
         guard case .rejected(let event) = result else {
             return XCTFail("Overdraft must be rejected")
@@ -67,7 +82,7 @@ final class WalletTests: XCTestCase {
         XCTAssertEqual(repository.snapshot().acceptedBalanceCents, before)
     }
 
-    func testLoanAndPartialRepaymentUseExactMinorUnits() {
+    func testLoanAndPartialRepaymentUseExactMinorUnits() async {
         let base = WalletSnapshot(
             acceptedBalanceCents: 1_000,
             activities: [],
@@ -78,11 +93,11 @@ final class WalletTests: XCTestCase {
             isStale: false
         )
         let repository = MockWalletRepository(snapshot: base)
-        _ = repository.submit(WalletCommand(kind: .loan, amountCents: 1_000, reason: "Bike helmet"))
+        _ = try! await repository.submit(WalletCommand(kind: .loan, amountCents: 1_000, reason: "Bike helmet"))
         XCTAssertEqual(repository.snapshot().acceptedBalanceCents, 2_000)
         XCTAssertEqual(repository.snapshot().loan?.remainingCents, 1_000)
 
-        _ = repository.submit(WalletCommand(kind: .repayment, amountCents: 250))
+        _ = try! await repository.submit(WalletCommand(kind: .repayment, amountCents: 250))
         XCTAssertEqual(repository.snapshot().acceptedBalanceCents, 1_750)
         XCTAssertEqual(repository.snapshot().loan?.remainingCents, 750)
     }


### PR DESCRIPTION
## Summary
- Wire AuthenticationServices Sign in with Apple with cryptographic nonce/state verification and keychain-backed opaque sessions.
- Add the production-only HTTP repository for the private /v1 contract, idempotent parent commands, authoritative child reads, cached stale states, and pending/rejected handling.
- Add family setup and secure local parent PIN setup, Sign in with Apple entitlement, API contract tests, and simulator operator documentation.

## Validation
- `xcodebuild -project EddysWallet.xcodeproj -scheme EddysWallet -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4" test CODE_SIGNING_ALLOWED=NO`
- 14 tests passed.
- `xcodebuild -project EddysWallet.xcodeproj -scheme EddysWallet -destination "generic/platform=iOS" build CODE_SIGNING_ALLOWED=NO`

## Important
The final real-account simulator test is intentionally not claimed. It requires the production endpoint at `https://eddieswallet.kunchenguid.com` and the remaining Apple Developer, DNS, TLS, and backend operator configuration documented in `EddysWallet/README.md`.