### PR TITLE
Fix Apple Sign In timeout recovery

### DIFF
--- a/EddysWallet/Models/AppleSignIn.swift
+++ b/EddysWallet/Models/AppleSignIn.swift
@@ -9,6 +9,7 @@ protocol AppleAuthorizationController: AnyObject {
         presentationContextProvider: ASAuthorizationControllerPresentationContextProviding
     )
     func performRequests()
+    func cancel()
 }
 
 typealias AppleAuthorizationControllerFactory = @MainActor (ASAuthorizationRequest) -> any AppleAuthorizationController
@@ -33,6 +34,10 @@ private final class SystemAppleAuthorizationController: AppleAuthorizationContro
 
     func performRequests() {
         controller.performRequests()
+    }
+
+    func cancel() {
+        controller.cancel()
     }
 }
 
@@ -100,11 +105,11 @@ public final class AppleSignInCoordinator: NSObject, ASAuthorizationControllerDe
             try await withCheckedThrowingContinuation { continuation in
                 self.continuation = continuation
                 guard self.activeAttemptID == attemptID else {
-                    self.finish(.failure(CancellationError()), attemptID: attemptID)
+                    self.finish(.failure(CancellationError()), attemptID: attemptID, cancelController: true)
                     return
                 }
                 if self.cancellationRequestedFor == attemptID || Task.isCancelled {
-                    self.finish(.failure(CancellationError()), attemptID: attemptID)
+                    self.finish(.failure(CancellationError()), attemptID: attemptID, cancelController: true)
                     return
                 }
 
@@ -199,20 +204,25 @@ public final class AppleSignInCoordinator: NSObject, ASAuthorizationControllerDe
             cancellationRequestedFor = attemptID
             return
         }
-        finish(.failure(CancellationError()), attemptID: attemptID)
+        finish(.failure(CancellationError()), attemptID: attemptID, cancelController: true)
     }
 
     private func timedOut(attemptID: UUID) {
-        finish(.failure(WalletAPIError.timedOut), attemptID: attemptID)
+        finish(.failure(WalletAPIError.timedOut), attemptID: attemptID, cancelController: true)
     }
 
-    private func finish(_ result: Result<AuthSession, Error>, attemptID: UUID? = nil) {
+    private func finish(
+        _ result: Result<AuthSession, Error>,
+        attemptID: UUID? = nil,
+        cancelController: Bool = false
+    ) {
         guard let activeAttemptID,
               attemptID == nil || attemptID == activeAttemptID else {
             return
         }
 
         let continuation = continuation
+        let adapter = authorizationControllerAdapter
         self.continuation = nil
         self.activeAttemptID = nil
         self.cancellationRequestedFor = nil
@@ -222,8 +232,11 @@ public final class AppleSignInCoordinator: NSObject, ASAuthorizationControllerDe
         timeoutTask = nil
         exchangeTask?.cancel()
         exchangeTask = nil
-        authorizationControllerAdapter = nil
         activeAuthorizationControllerID = nil
+        if cancelController {
+            adapter?.cancel()
+        }
+        authorizationControllerAdapter = nil
         continuation?.resume(with: result)
     }
 }

--- a/EddysWallet/Models/AppleSignIn.swift
+++ b/EddysWallet/Models/AppleSignIn.swift
@@ -2,25 +2,88 @@ import AuthenticationServices
 import UIKit
 
 @MainActor
+protocol AppleAuthorizationController: AnyObject {
+    var identifier: ObjectIdentifier { get }
+    func configure(
+        delegate: ASAuthorizationControllerDelegate,
+        presentationContextProvider: ASAuthorizationControllerPresentationContextProviding
+    )
+    func performRequests()
+}
+
+typealias AppleAuthorizationControllerFactory = @MainActor (ASAuthorizationRequest) -> any AppleAuthorizationController
+
+@MainActor
+private final class SystemAppleAuthorizationController: AppleAuthorizationController {
+    private let controller: ASAuthorizationController
+
+    init(request: ASAuthorizationRequest) {
+        controller = ASAuthorizationController(authorizationRequests: [request])
+    }
+
+    var identifier: ObjectIdentifier { ObjectIdentifier(controller) }
+
+    func configure(
+        delegate: ASAuthorizationControllerDelegate,
+        presentationContextProvider: ASAuthorizationControllerPresentationContextProviding
+    ) {
+        controller.delegate = delegate
+        controller.presentationContextProvider = presentationContextProvider
+    }
+
+    func performRequests() {
+        controller.performRequests()
+    }
+}
+
+@MainActor
 public final class AppleSignInCoordinator: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
+    private static let defaultTimeoutNanoseconds: UInt64 = 30_000_000_000
+
     private let authenticator: any ParentAuthenticator
+    private let controllerFactory: AppleAuthorizationControllerFactory
+    private let timeoutNanoseconds: UInt64
     private var continuation: CheckedContinuation<AuthSession, Error>?
     private var expectedState: String?
     private var expectedSignedNonce: String?
+    private var activeAttemptID: UUID?
+    private var cancellationRequestedFor: UUID?
+    private var authorizationControllerAdapter: (any AppleAuthorizationController)?
+    private var activeAuthorizationControllerID: ObjectIdentifier?
+    private var timeoutTask: Task<Void, Never>?
+    private var exchangeTask: Task<Void, Never>?
 
-    public init(authenticator: any ParentAuthenticator) {
+    public convenience init(authenticator: any ParentAuthenticator) {
+        self.init(
+            authenticator: authenticator,
+            timeoutNanoseconds: Self.defaultTimeoutNanoseconds,
+            controllerFactory: { request in SystemAppleAuthorizationController(request: request) }
+        )
+    }
+
+    init(
+        authenticator: any ParentAuthenticator,
+        timeoutNanoseconds: UInt64,
+        controllerFactory: @escaping AppleAuthorizationControllerFactory
+    ) {
         self.authenticator = authenticator
+        self.timeoutNanoseconds = timeoutNanoseconds
+        self.controllerFactory = controllerFactory
     }
 
     public func signIn() async throws -> AuthSession {
-        guard continuation == nil else {
+        guard continuation == nil, activeAttemptID == nil else {
             throw WalletAPIError.server(statusCode: 409, code: "AUTHENTICATION_IN_PROGRESS", message: "Sign in is already in progress.")
         }
+
         let rawNonce = try AppleNonce.randomString()
         let signedNonce = AppleNonce.sha256(rawNonce)
         let state = try AppleNonce.randomString()
+        let attemptID = UUID()
         expectedState = state
         expectedSignedNonce = signedNonce
+        activeAttemptID = attemptID
+        cancellationRequestedFor = nil
 
         let request = ASAuthorizationAppleIDProvider().createRequest()
         request.requestedScopes = [.email]
@@ -28,20 +91,47 @@ public final class AppleSignInCoordinator: NSObject, ASAuthorizationControllerDe
         // nonce is sent to the API, which verifies it against that claim.
         request.nonce = signedNonce
         request.state = state
-        let controller = ASAuthorizationController(authorizationRequests: [request])
-        controller.delegate = self
-        controller.presentationContextProvider = self
+        let adapter = controllerFactory(request)
+        authorizationControllerAdapter = adapter
+        activeAuthorizationControllerID = adapter.identifier
+        adapter.configure(delegate: self, presentationContextProvider: self)
 
-        return try await withCheckedThrowingContinuation { continuation in
-            self.continuation = continuation
-            controller.performRequests()
-        }
+        return try await withTaskCancellationHandler(operation: {
+            try await withCheckedThrowingContinuation { continuation in
+                self.continuation = continuation
+                guard self.activeAttemptID == attemptID else {
+                    self.finish(.failure(CancellationError()), attemptID: attemptID)
+                    return
+                }
+                if self.cancellationRequestedFor == attemptID || Task.isCancelled {
+                    self.finish(.failure(CancellationError()), attemptID: attemptID)
+                    return
+                }
+
+                let timeoutNanoseconds = self.timeoutNanoseconds
+                self.timeoutTask = Task { [weak self] in
+                    do {
+                        try await Task.sleep(nanoseconds: timeoutNanoseconds)
+                    } catch {
+                        return
+                    }
+                    guard !Task.isCancelled else { return }
+                    await self?.timedOut(attemptID: attemptID)
+                }
+                adapter.performRequests()
+            }
+        }, onCancel: {
+            Task { @MainActor [weak self] in
+                self?.cancel(attemptID: attemptID)
+            }
+        })
     }
 
     public func authorizationController(
         controller: ASAuthorizationController,
         didCompleteWithAuthorization authorization: ASAuthorization
     ) {
+        guard isActive(ObjectIdentifier(controller)) else { return }
         guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential else {
             finish(.failure(WalletAPIError.invalidResponse("Apple Sign In returned an unsupported credential.")))
             return
@@ -58,13 +148,14 @@ public final class AppleSignInCoordinator: NSObject, ASAuthorizationControllerDe
             return
         }
 
-        Task { @MainActor [weak self] in
-            guard let self else { return }
+        let attemptID = activeAttemptID
+        exchangeTask = Task { @MainActor [weak self] in
+            guard let self, let attemptID else { return }
             do {
-                let session = try await authenticator.authenticateApple(identityToken: identityTokenString, nonce: signedNonce)
-                finish(.success(session))
+                let session = try await self.authenticator.authenticateApple(identityToken: identityTokenString, nonce: signedNonce)
+                self.finish(.success(session), attemptID: attemptID)
             } catch {
-                finish(.failure(error))
+                self.finish(.failure(error), attemptID: attemptID)
             }
         }
     }
@@ -73,6 +164,11 @@ public final class AppleSignInCoordinator: NSObject, ASAuthorizationControllerDe
         controller: ASAuthorizationController,
         didCompleteWithError error: Error
     ) {
+        authorizationControllerDidCompleteWithError(error, controllerID: ObjectIdentifier(controller))
+    }
+
+    func authorizationControllerDidCompleteWithError(_ error: Error, controllerID: ObjectIdentifier) {
+        guard isActive(controllerID) else { return }
         if let authorizationError = error as? ASAuthorizationError,
            authorizationError.code == .canceled {
             finish(.failure(WalletAPIError.cancelled))
@@ -89,11 +185,45 @@ public final class AppleSignInCoordinator: NSObject, ASAuthorizationControllerDe
             ?? ASPresentationAnchor()
     }
 
-    private func finish(_ result: Result<AuthSession, Error>) {
+    private func isActive(_ controllerID: ObjectIdentifier) -> Bool {
+        guard continuation != nil,
+              let activeControllerID = activeAuthorizationControllerID else {
+            return false
+        }
+        return activeControllerID == controllerID
+    }
+
+    private func cancel(attemptID: UUID) {
+        guard activeAttemptID == attemptID else { return }
+        guard continuation != nil else {
+            cancellationRequestedFor = attemptID
+            return
+        }
+        finish(.failure(CancellationError()), attemptID: attemptID)
+    }
+
+    private func timedOut(attemptID: UUID) {
+        finish(.failure(WalletAPIError.timedOut), attemptID: attemptID)
+    }
+
+    private func finish(_ result: Result<AuthSession, Error>, attemptID: UUID? = nil) {
+        guard let activeAttemptID,
+              attemptID == nil || attemptID == activeAttemptID else {
+            return
+        }
+
         let continuation = continuation
         self.continuation = nil
-        expectedState = nil
-        expectedSignedNonce = nil
+        self.activeAttemptID = nil
+        self.cancellationRequestedFor = nil
+        self.expectedState = nil
+        self.expectedSignedNonce = nil
+        timeoutTask?.cancel()
+        timeoutTask = nil
+        exchangeTask?.cancel()
+        exchangeTask = nil
+        authorizationControllerAdapter = nil
+        activeAuthorizationControllerID = nil
         continuation?.resume(with: result)
     }
 }

--- a/EddysWallet/Models/WalletAPI.swift
+++ b/EddysWallet/Models/WalletAPI.swift
@@ -14,6 +14,7 @@ public enum WalletAPIError: Error, Equatable, LocalizedError {
     case unauthorized
     case familyNotSetup
     case cancelled
+    case timedOut
     case server(statusCode: Int, code: String, message: String)
     case network(String)
     case invalidResponse(String)
@@ -25,6 +26,7 @@ public enum WalletAPIError: Error, Equatable, LocalizedError {
         case .unauthorized: "Your parent session expired. Sign in with Apple again."
         case .familyNotSetup: "Finish parent and child setup before opening the wallet."
         case .cancelled: "Sign in was cancelled."
+        case .timedOut: "Apple Sign In took too long. Please try again."
         case let .server(_, _, message): message
         case let .network(message): message
         case let .invalidResponse(message): message
@@ -542,7 +544,7 @@ public final class APIWalletRepository: WalletRepository, ParentAuthenticator {
                 let event = makeLocalEvent(for: command, state: .rejected, message: message, rejectionReason: message)
                 rejectedEvents.insert(event, at: 0)
                 return .rejected(event)
-            case .cancelled, .familyNotSetup:
+            case .cancelled, .timedOut, .familyNotSetup:
                 throw error
             case .server, .network, .invalidResponse, .invalidConfiguration:
                 pendingCommands[command.idempotencyKey] = command

--- a/EddysWallet/README.md
+++ b/EddysWallet/README.md
@@ -23,11 +23,29 @@ xcodebuild -project EddysWallet.xcodeproj -scheme EddysWallet \
 
 Unit and contract-style transport tests cover Apple session exchange, bearer sessions, idempotency headers, authoritative virtual-money responses, pending network commands, expired sessions, and invalid responses. Tests inject `HTTPTransport` and `InMemorySessionStore`; they do not call the production service.
 
+## Apple Sign In signing prerequisite
+
+The source project declares the Sign in with Apple capability and `EddysWallet/EddysWallet.entitlements` contains `com.apple.developer.applesignin`. That source configuration does not guarantee that a locally built app is entitled: the captain must be signed into Xcode with the Apple Development team that owns the explicit App ID `com.kunchenguid.eddyswallet`, with Sign in with Apple enabled and a usable Apple Development certificate/account setup. This is an external prerequisite and cannot be supplied by this public repository. Do not commit a Team ID, provisioning profile, certificate, private key, or Apple account data.
+
+After building, inspect the signed bundle rather than only the project settings:
+
+```sh
+rm -rf .derived
+xcodebuild -project EddysWallet.xcodeproj -scheme EddysWallet \
+  -configuration Debug \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' \
+  -derivedDataPath .derived build
+codesign -d --entitlements :- \
+  .derived/Build/Products/Debug-iphonesimulator/EddysWallet.app 2>&1
+```
+
+The output must contain `com.apple.developer.applesignin` with the `Default` value. If it is absent, the bundle is locally/ad hoc signed without the capability and the Apple Development signing setup must be fixed before testing native Apple authorization. A correctly entitled bundle is required but does not by itself prove that an Apple-side 401 or `AKAuthenticationError -7026` has been resolved.
+
 ## Manual simulator sequence
 
 This is the exact final-account test sequence. It has **not** been run to claim live end-to-end success because the production endpoint still needs to be available.
 
-1. In Apple Developer, confirm the explicit App ID `com.kunchenguid.eddyswallet` has Sign in with Apple enabled. In Xcode, select a locally configured signing team for the target; do not commit that Team ID.
+1. Complete the Apple Development signing prerequisite above. In Apple Developer, confirm the explicit App ID `com.kunchenguid.eddyswallet` has Sign in with Apple enabled. Do not commit the Team ID.
 2. The service operator configures the single production host and TLS for `https://eddieswallet.kunchenguid.com`, sets the backend Apple audience to `com.kunchenguid.eddyswallet`, and verifies `GET https://eddieswallet.kunchenguid.com/healthz` is healthy. No Apple private key is needed by this native flow.
 3. Build and run the `EddysWallet` scheme on an iOS 17+ simulator with the app's registered bundle identifier. Sign in with Apple using the simulator's Apple ID/test account.
 4. Confirm the app reaches the parent setup form. Enter a nickname, lesson age band, and a four-digit parent PIN, create the wallet, and confirm that setup only appears as complete after the service accepts `POST /v1/family/setup`. The PIN is stored only in the platform keychain and gates parent mode locally.
@@ -38,4 +56,4 @@ This is the exact final-account test sequence. It has **not** been run to claim 
 9. Expire or revoke the session on the service, make a request, and confirm the app clears the keychain session and returns to the Apple sign-in screen without displaying usable family data.
 10. Record the result as an operator test report. Do not mark this repository or pull request as live end-to-end verified until the real production endpoint and real-account simulator run are complete.
 
-Remaining operator configuration is intentionally outside this repository: Apple Developer capability/signing configuration, DNS and TLS for `eddieswallet.kunchenguid.com`, backend `APPLE_AUDIENCES=com.kunchenguid.eddyswallet`, and the production service's backups, exports, and deployment health checks. No Team ID, token, credential, or private key belongs in Git.
+Remaining operator configuration is intentionally outside this repository: the Apple Development account/certificate and capability setup described above, DNS and TLS for `eddieswallet.kunchenguid.com`, backend `APPLE_AUDIENCES=com.kunchenguid.eddyswallet`, and the production service's backups, exports, and deployment health checks. No Team ID, token, credential, or private key belongs in Git.

--- a/EddysWalletTests/WalletTests.swift
+++ b/EddysWalletTests/WalletTests.swift
@@ -1,3 +1,4 @@
+import AuthenticationServices
 import XCTest
 @testable import EddysWallet
 
@@ -109,5 +110,232 @@ final class WalletTests: XCTestCase {
         _ = try! await repository.submit(WalletCommand(kind: .repayment, amountCents: 250))
         XCTAssertEqual(repository.snapshot().acceptedBalanceCents, 1_750)
         XCTAssertEqual(repository.snapshot().loan?.remainingCents, 750)
+    }
+
+    func testAppleSignInTimeoutCleansUpAndLeavesRetryableStoreState() async {
+        let controller = TestAppleAuthorizationController()
+        let coordinator = AppleSignInCoordinator(
+            authenticator: TestParentAuthenticator(),
+            timeoutNanoseconds: 20_000_000,
+            controllerFactory: { _ in controller }
+        )
+        let store = WalletStore(
+            repository: MockWalletRepository(),
+            appleSignInCoordinator: coordinator,
+            initiallySignedIn: false
+        )
+
+        await store.signInWithApple()
+
+        XCTAssertFalse(store.isSigningIn)
+        XCTAssertEqual(store.errorMessage, WalletAPIError.timedOut.localizedDescription)
+        XCTAssertEqual(controller.performCount, 1)
+
+        do {
+            _ = try await coordinator.signIn()
+            XCTFail("A timed-out authorization must fail")
+        } catch let error as WalletAPIError {
+            XCTAssertEqual(error, .timedOut)
+        } catch {
+            XCTFail("Unexpected retry error: \(error)")
+        }
+        XCTAssertEqual(controller.performCount, 2)
+    }
+
+    func testAppleSignInCancellationCleansUpContinuation() async {
+        let controller = TestAppleAuthorizationController()
+        let coordinator = AppleSignInCoordinator(
+            authenticator: TestParentAuthenticator(),
+            timeoutNanoseconds: 1_000_000_000,
+            controllerFactory: { _ in controller }
+        )
+        let task = Task { @MainActor () throws -> AuthSession in
+            try await coordinator.signIn()
+        }
+        while controller.performCount == 0 {
+            await Task.yield()
+        }
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("Cancellation must finish the authorization continuation")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected cancellation error: \(error)")
+        }
+
+        let retryTask = Task { @MainActor () throws -> AuthSession in
+            try await coordinator.signIn()
+        }
+        while controller.performCount < 2 {
+            await Task.yield()
+        }
+        retryTask.cancel()
+        do {
+            _ = try await retryTask.value
+            XCTFail("A cancelled retry must fail")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected retry error: \(error)")
+        }
+        XCTAssertEqual(controller.performCount, 2)
+    }
+
+    func testAppleAuthorizationErrorCleansUpAndDoesNotExposeAppleErrorData() async {
+        let controller = TestAppleAuthorizationController()
+        let coordinator = AppleSignInCoordinator(
+            authenticator: TestParentAuthenticator(),
+            timeoutNanoseconds: 1_000_000_000,
+            controllerFactory: { _ in controller }
+        )
+        let task = Task { @MainActor () throws -> AuthSession in
+            try await coordinator.signIn()
+        }
+        while controller.performCount == 0 {
+            await Task.yield()
+        }
+
+        coordinator.authorizationControllerDidCompleteWithError(
+            ASAuthorizationError(.failed),
+            controllerID: controller.identifier
+        )
+
+        do {
+            _ = try await task.value
+            XCTFail("An authorization error must fail the sign-in")
+        } catch let error as WalletAPIError {
+            XCTAssertEqual(error, .network("Apple Sign In could not be completed. Please try again."))
+        } catch {
+            XCTFail("Unexpected authorization error: \(error)")
+        }
+
+        do {
+            _ = try await coordinator.signIn()
+            XCTFail("An authorization error must clean up the active attempt")
+        } catch let error as WalletAPIError {
+            XCTAssertEqual(error, .timedOut)
+        } catch {
+            XCTFail("Unexpected retry error: \(error)")
+        }
+    }
+
+    func testAppleAuthorizationCancellationCleansUpContinuation() async {
+        let controller = TestAppleAuthorizationController()
+        let coordinator = AppleSignInCoordinator(
+            authenticator: TestParentAuthenticator(),
+            timeoutNanoseconds: 1_000_000_000,
+            controllerFactory: { _ in controller }
+        )
+        let task = Task { @MainActor () throws -> AuthSession in
+            try await coordinator.signIn()
+        }
+        while controller.performCount == 0 {
+            await Task.yield()
+        }
+
+        coordinator.authorizationControllerDidCompleteWithError(
+            ASAuthorizationError(.canceled),
+            controllerID: controller.identifier
+        )
+
+        do {
+            _ = try await task.value
+            XCTFail("Apple cancellation must fail the sign-in")
+        } catch let error as WalletAPIError {
+            XCTAssertEqual(error, .cancelled)
+        } catch {
+            XCTFail("Unexpected Apple cancellation error: \(error)")
+        }
+
+        let retryTask = Task { @MainActor () throws -> AuthSession in
+            try await coordinator.signIn()
+        }
+        while controller.performCount < 2 {
+            await Task.yield()
+        }
+        retryTask.cancel()
+        do {
+            _ = try await retryTask.value
+            XCTFail("The retry must remain cancellable")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected retry error: \(error)")
+        }
+    }
+
+    func testStaleAuthorizationCallbackCannotCompleteANewAttempt() async {
+        let firstController = TestAppleAuthorizationController()
+        let secondController = TestAppleAuthorizationController()
+        var controllers = [firstController, secondController]
+        let coordinator = AppleSignInCoordinator(
+            authenticator: TestParentAuthenticator(),
+            timeoutNanoseconds: 1_000_000_000,
+            controllerFactory: { _ in controllers.removeFirst() }
+        )
+
+        let firstTask = Task { @MainActor () throws -> AuthSession in
+            try await coordinator.signIn()
+        }
+        while firstController.performCount == 0 {
+            await Task.yield()
+        }
+        firstTask.cancel()
+        do {
+            _ = try await firstTask.value
+            XCTFail("The first attempt should be cancelled")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected first-attempt error: \(error)")
+        }
+
+        let secondTask = Task { @MainActor () throws -> AuthSession in
+            try await coordinator.signIn()
+        }
+        while secondController.performCount == 0 {
+            await Task.yield()
+        }
+        coordinator.authorizationControllerDidCompleteWithError(
+            ASAuthorizationError(.failed),
+            controllerID: firstController.identifier
+        )
+        secondTask.cancel()
+
+        do {
+            _ = try await secondTask.value
+            XCTFail("A stale callback must not complete the new attempt")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected second-attempt error: \(error)")
+        }
+    }
+}
+
+@MainActor
+private final class TestParentAuthenticator: ParentAuthenticator {
+    func authenticateApple(identityToken: String, nonce: String) async throws -> AuthSession {
+        AuthSession(token: "test-session", expiresAt: Date(timeIntervalSince1970: 4_000_000_000))
+    }
+}
+
+@MainActor
+private final class TestAppleAuthorizationController: AppleAuthorizationController {
+    private let token = NSObject()
+    private(set) var performCount = 0
+
+    var identifier: ObjectIdentifier { ObjectIdentifier(token) }
+
+    func configure(
+        delegate: ASAuthorizationControllerDelegate,
+        presentationContextProvider: ASAuthorizationControllerPresentationContextProviding
+    ) {}
+
+    func performRequests() {
+        performCount += 1
     }
 }

--- a/EddysWalletTests/WalletTests.swift
+++ b/EddysWalletTests/WalletTests.swift
@@ -119,6 +119,12 @@ final class WalletTests: XCTestCase {
             timeoutNanoseconds: 20_000_000,
             controllerFactory: { _ in controller }
         )
+        controller.onCancel = {
+            coordinator.authorizationControllerDidCompleteWithError(
+                ASAuthorizationError(.failed),
+                controllerID: controller.identifier
+            )
+        }
         let store = WalletStore(
             repository: MockWalletRepository(),
             appleSignInCoordinator: coordinator,
@@ -130,6 +136,7 @@ final class WalletTests: XCTestCase {
         XCTAssertFalse(store.isSigningIn)
         XCTAssertEqual(store.errorMessage, WalletAPIError.timedOut.localizedDescription)
         XCTAssertEqual(controller.performCount, 1)
+        XCTAssertEqual(controller.cancelCount, 1)
 
         do {
             _ = try await coordinator.signIn()
@@ -140,6 +147,7 @@ final class WalletTests: XCTestCase {
             XCTFail("Unexpected retry error: \(error)")
         }
         XCTAssertEqual(controller.performCount, 2)
+        XCTAssertEqual(controller.cancelCount, 2)
     }
 
     func testAppleSignInCancellationCleansUpContinuation() async {
@@ -165,6 +173,7 @@ final class WalletTests: XCTestCase {
         } catch {
             XCTFail("Unexpected cancellation error: \(error)")
         }
+        XCTAssertEqual(controller.cancelCount, 1)
 
         let retryTask = Task { @MainActor () throws -> AuthSession in
             try await coordinator.signIn()
@@ -182,6 +191,7 @@ final class WalletTests: XCTestCase {
             XCTFail("Unexpected retry error: \(error)")
         }
         XCTAssertEqual(controller.performCount, 2)
+        XCTAssertEqual(controller.cancelCount, 2)
     }
 
     func testAppleAuthorizationErrorCleansUpAndDoesNotExposeAppleErrorData() async {
@@ -211,6 +221,7 @@ final class WalletTests: XCTestCase {
         } catch {
             XCTFail("Unexpected authorization error: \(error)")
         }
+        XCTAssertEqual(controller.cancelCount, 0)
 
         do {
             _ = try await coordinator.signIn()
@@ -220,6 +231,7 @@ final class WalletTests: XCTestCase {
         } catch {
             XCTFail("Unexpected retry error: \(error)")
         }
+        XCTAssertEqual(controller.cancelCount, 1)
     }
 
     func testAppleAuthorizationCancellationCleansUpContinuation() async {
@@ -265,6 +277,7 @@ final class WalletTests: XCTestCase {
         } catch {
             XCTFail("Unexpected retry error: \(error)")
         }
+        XCTAssertEqual(controller.cancelCount, 1)
     }
 
     func testStaleAuthorizationCallbackCannotCompleteANewAttempt() async {
@@ -313,6 +326,8 @@ final class WalletTests: XCTestCase {
         } catch {
             XCTFail("Unexpected second-attempt error: \(error)")
         }
+        XCTAssertEqual(firstController.cancelCount, 1)
+        XCTAssertEqual(secondController.cancelCount, 1)
     }
 }
 
@@ -327,6 +342,8 @@ private final class TestParentAuthenticator: ParentAuthenticator {
 private final class TestAppleAuthorizationController: AppleAuthorizationController {
     private let token = NSObject()
     private(set) var performCount = 0
+    private(set) var cancelCount = 0
+    var onCancel: (() -> Void)?
 
     var identifier: ObjectIdentifier { ObjectIdentifier(token) }
 
@@ -337,5 +354,10 @@ private final class TestAppleAuthorizationController: AppleAuthorizationControll
 
     func performRequests() {
         performCount += 1
+    }
+
+    func cancel() {
+        cancelCount += 1
+        onCancel?()
     }
 }


### PR DESCRIPTION
## Summary
- Add a bounded 30-second timeout to native Apple authorization and make cancellation/error cleanup resume the pending continuation exactly once.
- Ignore callbacks from stale authorization controllers and keep nonce/state validation unchanged.
- Add focused timeout, cancellation, error, and stale-callback tests.
- Document the Apple Development signing prerequisite and the signed-bundle entitlement verification command.

## Proven cause and scope
The pre-fix simulator build used Xcode signing identity `Sign to Run Locally`. Inspecting the actual app with `codesign -d --entitlements :-` showed an empty entitlement dictionary and `TeamIdentifier=not set`, while the source capability and entitlement file were present. This confirms the local signed-bundle limitation. It does not prove signing alone caused the Apple-side 401 or `AKAuthenticationError -7026`, since the earlier automatic-signing run also reached the native sheet and failed at the same Apple boundary.

The app-side failure was independently actionable: if AuthKit never calls either delegate method, the old checked continuation never resumed and the UI stayed disabled indefinitely. The new timeout returns a retryable message and clears all authorization state; task cancellation, AuthKit errors, backend exchange cancellation, and stale callbacks are also cleanup-safe.

## Validation
- `xcodebuild ... test`: 21 tests passed on the iOS 26.4 simulator.
- Simulator build succeeded.
- Signed bundle was inspected with `codesign`; local signing still has no Apple entitlement, as expected without the captain-owned Apple Development setup.
- `plutil -lint EddysWallet/EddysWallet.entitlements` and `git diff --check` passed.

No real credentials, Apple account data, certificates, provisioning profiles, or private keys were used or added. Do not merge this PR.