### PR TITLE
Correct Eddie's Wallet Apple bundle identifier

### DIFF
--- a/EddysWallet.xcodeproj/project.pbxproj
+++ b/EddysWallet.xcodeproj/project.pbxproj
@@ -289,7 +289,6 @@
 				CODE_SIGN_ENTITLEMENTS = EddysWallet/EddysWallet.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
 				ENABLE_TESTABILITY = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "Eddie's Wallet";
@@ -302,7 +301,7 @@
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/Frameworks");
-				PRODUCT_BUNDLE_IDENTIFIER = com.kunchenguid.eddyswallet;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kunchenguid.eddieswallet;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -328,7 +327,7 @@
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				LD_RUNPATH_SEARCH_PATHS = ("$(inherited)", "@executable_path/Frameworks");
-				PRODUCT_BUNDLE_IDENTIFIER = com.kunchenguid.eddyswallet;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kunchenguid.eddieswallet;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -344,7 +343,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kunchenguid.eddyswallet.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kunchenguid.eddieswallet.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;
@@ -361,7 +360,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.kunchenguid.eddyswallet.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.kunchenguid.eddieswallet.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;

--- a/EddysWallet/Models/WalletAPI.swift
+++ b/EddysWallet/Models/WalletAPI.swift
@@ -2,11 +2,53 @@ import CryptoKit
 import Foundation
 import Security
 
+public enum AppleAppIdentity {
+    public static let bundleIdentifier = "com.kunchenguid.eddieswallet"
+    public static let backendAppleAudience = bundleIdentifier
+    public static let testBundleIdentifier = "\(bundleIdentifier).tests"
+}
+
 public enum APIConfiguration {
     /// The only shipped API environment. The backend operator must provision this
     /// host and TLS before a real-account simulator test can pass.
     public static let productionBaseURL = URL(string: "https://eddieswallet.kunchenguid.com")!
     public static let productionBaseURLString = "https://eddieswallet.kunchenguid.com"
+}
+
+enum KeychainServiceMigration {
+    static let currentSessionService = "\(AppleAppIdentity.bundleIdentifier).session"
+    // Compatibility aliases for pre-correction builds. Migration changes only the service attribute.
+    static let legacySessionService = "com.kunchenguid.eddyswallet.session"
+    static let currentParentPINService = "\(AppleAppIdentity.bundleIdentifier).parent-pin"
+    static let legacyParentPINService = "com.kunchenguid.eddyswallet.parent-pin"
+
+    static func legacyService(forCurrentService service: String) -> String? {
+        switch service {
+        case currentSessionService: legacySessionService
+        case currentParentPINService: legacyParentPINService
+        default: nil
+        }
+    }
+
+    /// Rename only the keychain item's service attribute. This does not read,
+    /// log, or copy the protected value.
+    static func renameItemIfNeeded(currentService: String, legacyService: String, account: String) {
+        guard currentService != legacyService else { return }
+        let currentQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: currentService,
+            kSecAttrAccount as String: account
+        ]
+        guard SecItemCopyMatching(currentQuery as CFDictionary, nil) == errSecItemNotFound else { return }
+
+        let legacyQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: legacyService,
+            kSecAttrAccount as String: account
+        ]
+        let attributes: [String: Any] = [kSecAttrService as String: currentService]
+        _ = SecItemUpdate(legacyQuery as CFDictionary, attributes as CFDictionary)
+    }
 }
 
 public enum WalletAPIError: Error, Equatable, LocalizedError {
@@ -47,11 +89,12 @@ public final class KeychainSessionStore: SessionStore {
     private let service: String
     private let account = "parent-session"
 
-    public init(service: String = "com.kunchenguid.eddyswallet.session") {
+    public init(service: String = "\(AppleAppIdentity.bundleIdentifier).session") {
         self.service = service
     }
 
     public var session: AuthSession? {
+        migrateLegacyItemIfNeeded()
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
@@ -71,6 +114,7 @@ public final class KeychainSessionStore: SessionStore {
     }
 
     public func save(_ session: AuthSession) throws {
+        migrateLegacyItemIfNeeded()
         let data = try JSONEncoder().encode(session)
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -93,12 +137,22 @@ public final class KeychainSessionStore: SessionStore {
     }
 
     public func clear() {
+        migrateLegacyItemIfNeeded()
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account
         ]
         SecItemDelete(query as CFDictionary)
+    }
+
+    private func migrateLegacyItemIfNeeded() {
+        guard let legacyService = KeychainServiceMigration.legacyService(forCurrentService: service) else { return }
+        KeychainServiceMigration.renameItemIfNeeded(
+            currentService: service,
+            legacyService: legacyService,
+            account: account
+        )
     }
 
     private struct KeychainError: Error {
@@ -115,12 +169,13 @@ public protocol ParentPINStore: AnyObject {
 
 @MainActor
 public final class KeychainParentPINStore: ParentPINStore {
-    private let service = "com.kunchenguid.eddyswallet.parent-pin"
+    private let service = KeychainServiceMigration.currentParentPINService
     private let account = "parent-pin"
 
     public init() {}
 
     public var pin: String? {
+        migrateLegacyItemIfNeeded()
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
@@ -137,6 +192,7 @@ public final class KeychainParentPINStore: ParentPINStore {
     }
 
     public func save(pin: String) throws {
+        migrateLegacyItemIfNeeded()
         guard pin.count == 4, pin.allSatisfy(\.isNumber) else {
             throw WalletAPIError.invalidResponse("The parent PIN must contain four digits.")
         }
@@ -162,12 +218,21 @@ public final class KeychainParentPINStore: ParentPINStore {
     }
 
     public func clear() {
+        migrateLegacyItemIfNeeded()
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account
         ]
         SecItemDelete(query as CFDictionary)
+    }
+
+    private func migrateLegacyItemIfNeeded() {
+        KeychainServiceMigration.renameItemIfNeeded(
+            currentService: service,
+            legacyService: KeychainServiceMigration.legacyParentPINService,
+            account: account
+        )
     }
 }
 

--- a/EddysWallet/README.md
+++ b/EddysWallet/README.md
@@ -1,6 +1,6 @@
 # Native app
 
-`EddysWallet.xcodeproj` is a SwiftUI iOS/iPadOS app targeting iOS 17 and device families 1 and 2. The UI uses adaptive `horizontalSizeClass` layouts and native sheets, forms, navigation, Dynamic Type-friendly system fonts, and accessibility labels.
+`EddysWallet.xcodeproj` is a SwiftUI iOS/iPadOS app targeting iOS 17 and device families 1 and 2. The built app bundle identifier is `com.kunchenguid.eddieswallet`, matching the registered Apple App ID and the production Apple audience. The UI uses adaptive `horizontalSizeClass` layouts and native sheets, forms, navigation, Dynamic Type-friendly system fonts, and accessibility labels.
 
 ## Production configuration
 
@@ -12,7 +12,7 @@ https://eddieswallet.kunchenguid.com
 
 There is no staging or development API configuration in this client. The backend contract is the private service's `/v1` API: Apple session exchange, family setup, wallet and child-view reads, activity and loan details, weekly allowance rules and occurrences, deposits, withdrawals, loans, repayments, and required `Idempotency-Key` headers. `APIWalletRepository` is the concrete HTTP implementation behind `WalletRepository`; `MockWalletRepository` remains available for previews and unit tests.
 
-The opaque session token is stored with `KeychainSessionStore` using an after-first-unlock, this-device-only keychain item. Identity tokens and Apple private keys are not stored. A cached accepted snapshot is used for offline display and is marked stale when it cannot be refreshed. A command that has not received an authoritative accepted response is shown as **Waiting to sync** and does not change the accepted balance.
+The opaque session token is stored with `KeychainSessionStore` using the `com.kunchenguid.eddieswallet.session` service and an after-first-unlock, this-device-only keychain item. The parent PIN uses `com.kunchenguid.eddieswallet.parent-pin`. Identity tokens and Apple private keys are not stored. On upgrade, each store attempts a narrowly scoped in-place keychain service rename from its prior service before reading or writing; this uses `SecItemUpdate` and never logs or copies secret data. If the operating system does not permit access to the prior item after the App ID change, the user must sign in again or set a new PIN. A cached accepted snapshot is used for offline display and is marked stale when it cannot be refreshed. A command that has not received an authoritative accepted response is shown as **Waiting to sync** and does not change the accepted balance.
 
 ## Local development and tests
 
@@ -25,7 +25,7 @@ Unit and contract-style transport tests cover Apple session exchange, bearer ses
 
 ## Apple Sign In signing prerequisite
 
-The source project declares the Sign in with Apple capability and `EddysWallet/EddysWallet.entitlements` contains `com.apple.developer.applesignin`. That source configuration does not guarantee that a locally built app is entitled: the captain must be signed into Xcode with the Apple Development team that owns the explicit App ID `com.kunchenguid.eddyswallet`, with Sign in with Apple enabled and a usable Apple Development certificate/account setup. This is an external prerequisite and cannot be supplied by this public repository. Do not commit a Team ID, provisioning profile, certificate, private key, or Apple account data.
+The source project declares the Sign in with Apple capability and `EddysWallet/EddysWallet.entitlements` contains `com.apple.developer.applesignin`. That source configuration does not guarantee that a locally built app is entitled: the captain must be signed into Xcode with the Apple Development team that owns the explicit App ID `com.kunchenguid.eddieswallet`, with Sign in with Apple enabled and a usable Apple Development certificate/account setup. This is an external prerequisite and cannot be supplied by this public repository. Do not commit a Team ID, provisioning profile, certificate, private key, or Apple account data.
 
 After building, inspect the signed bundle rather than only the project settings:
 
@@ -45,8 +45,8 @@ The output must contain `com.apple.developer.applesignin` with the `Default` val
 
 This is the exact final-account test sequence. It has **not** been run to claim live end-to-end success because the production endpoint still needs to be available.
 
-1. Complete the Apple Development signing prerequisite above. In Apple Developer, confirm the explicit App ID `com.kunchenguid.eddyswallet` has Sign in with Apple enabled. Do not commit the Team ID.
-2. The service operator configures the single production host and TLS for `https://eddieswallet.kunchenguid.com`, sets the backend Apple audience to `com.kunchenguid.eddyswallet`, and verifies `GET https://eddieswallet.kunchenguid.com/healthz` is healthy. No Apple private key is needed by this native flow.
+1. Complete the Apple Development signing prerequisite above. In Apple Developer, confirm the explicit App ID `com.kunchenguid.eddieswallet` has Sign in with Apple enabled. Do not commit the Team ID.
+2. The service operator configures the single production host and TLS for `https://eddieswallet.kunchenguid.com`, sets the backend Apple audience to `com.kunchenguid.eddieswallet`, and verifies `GET https://eddieswallet.kunchenguid.com/healthz` is healthy. No Apple private key is needed by this native flow.
 3. Build and run the `EddysWallet` scheme on an iOS 17+ simulator with the app's registered bundle identifier. Sign in with Apple using the simulator's Apple ID/test account.
 4. Confirm the app reaches the parent setup form. Enter a nickname, lesson age band, and a four-digit parent PIN, create the wallet, and confirm that setup only appears as complete after the service accepts `POST /v1/family/setup`. The PIN is stored only in the platform keychain and gates parent mode locally.
 5. Confirm the parent wallet shows the accepted virtual balance and the fixed notice: “Virtual practice only. These dollars are pretend, cannot be redeemed, and never move real money.”
@@ -56,4 +56,4 @@ This is the exact final-account test sequence. It has **not** been run to claim 
 9. Expire or revoke the session on the service, make a request, and confirm the app clears the keychain session and returns to the Apple sign-in screen without displaying usable family data.
 10. Record the result as an operator test report. Do not mark this repository or pull request as live end-to-end verified until the real production endpoint and real-account simulator run are complete.
 
-Remaining operator configuration is intentionally outside this repository: the Apple Development account/certificate and capability setup described above, DNS and TLS for `eddieswallet.kunchenguid.com`, backend `APPLE_AUDIENCES=com.kunchenguid.eddyswallet`, and the production service's backups, exports, and deployment health checks. No Team ID, token, credential, or private key belongs in Git.
+Remaining operator configuration is intentionally outside this repository: the Apple Development account/certificate and capability setup described above, DNS and TLS for `eddieswallet.kunchenguid.com`, backend `APPLE_AUDIENCES=com.kunchenguid.eddieswallet`, and the production service's backups, exports, and deployment health checks. No Team ID, token, credential, or private key belongs in Git.

--- a/EddysWalletTests/APIRepositoryTests.swift
+++ b/EddysWalletTests/APIRepositoryTests.swift
@@ -4,6 +4,28 @@ import XCTest
 
 @MainActor
 final class APIRepositoryTests: XCTestCase {
+    func testBuiltBundleAndBackendAudienceUseRegisteredAppleAppID() {
+        XCTAssertEqual(AppleAppIdentity.bundleIdentifier, "com.kunchenguid.eddieswallet")
+        XCTAssertEqual(AppleAppIdentity.backendAppleAudience, "com.kunchenguid.eddieswallet")
+        XCTAssertEqual(AppleAppIdentity.testBundleIdentifier, "com.kunchenguid.eddieswallet.tests")
+        XCTAssertEqual(Bundle(for: APIRepositoryTests.self).bundleIdentifier, AppleAppIdentity.testBundleIdentifier)
+        XCTAssertEqual(Bundle(identifier: AppleAppIdentity.bundleIdentifier)?.bundleIdentifier, AppleAppIdentity.bundleIdentifier)
+    }
+
+    func testKeychainServiceMigrationUsesInPlaceLegacyRenameWithoutSecretData() {
+        XCTAssertEqual(KeychainServiceMigration.currentSessionService, "com.kunchenguid.eddieswallet.session")
+        XCTAssertEqual(KeychainServiceMigration.currentParentPINService, "com.kunchenguid.eddieswallet.parent-pin")
+        XCTAssertEqual(
+            KeychainServiceMigration.legacyService(forCurrentService: KeychainServiceMigration.currentSessionService),
+            "com.kunchenguid.eddyswallet.session"
+        )
+        XCTAssertEqual(
+            KeychainServiceMigration.legacyService(forCurrentService: KeychainServiceMigration.currentParentPINService),
+            "com.kunchenguid.eddyswallet.parent-pin"
+        )
+        XCTAssertNil(KeychainServiceMigration.legacyService(forCurrentService: "com.example.other"))
+    }
+
     func testProductionConfigurationShipsTheRealBackendURL() {
         XCTAssertEqual(APIConfiguration.productionBaseURLString, "https://eddieswallet.kunchenguid.com")
         XCTAssertEqual(APIConfiguration.productionBaseURL.absoluteString, "https://eddieswallet.kunchenguid.com")


### PR DESCRIPTION
## Summary
- Correct the app and unit-test bundle identifiers to the registered Apple App ID family.
- Keep the Sign in with Apple entitlement on the app target and remove the empty committed DEVELOPMENT_TEAM setting.
- Correct keychain service identifiers with an in-place legacy service migration that never reads, logs, or copies secret data.
- Align public signing and production audience documentation, with contract tests for built identifiers and audience.

## Validation
- `xcodebuild -project EddysWallet.xcodeproj -scheme EddysWallet -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.4' -derivedDataPath .derived test`
- 23 simulator tests passed.
- Built app identifier: `com.kunchenguid.eddieswallet`.
- Built test identifier: `com.kunchenguid.eddieswallet.tests`.
- Source entitlement remains `com.apple.developer.applesignin = Default`.

Local signing note: no Apple Development identity is visible in this environment, so the simulator build is ad hoc and its signed entitlement plist is empty. The source entitlement and app target association remain present; device signing still requires the captain's Apple Development team setup.