### PR TITLE
fix(app-review): bind SOURCE-named subscription review screenshots

### DIFF
--- a/test/app-review-pipeline-test.py
+++ b/test/app-review-pipeline-test.py
@@ -649,6 +649,146 @@ class LiveReconciliationTests(FixtureCase):
         self.assertEqual(fake.writes, [])
 
 
+class SubscriptionReviewAssetBindingTests(FixtureCase):
+    """`_match_asset` binds a subscription review screenshot Apple names SOURCE.
+
+    App Store Connect reports a subscription App Review screenshot's `fileName`
+    as the literal sentinel `SOURCE` rather than the real uploaded name, even
+    after a correct re-upload, so the strict name+size+md5 predicate that binds a
+    listing screenshot matches zero approved files and the read refuses. These
+    tests exercise the observable binding behavior through the real transport.
+    """
+
+    IAP_PATH = "docs/app-store/iap/cloud-monthly.png"
+    LISTING_PATH = "docs/app-store/screenshots/iphone-67/01-wallet.png"
+
+    def transport(self, verified):
+        return content.CandidateReadTransport(None, self.fixture.candidate, verified)
+
+    def client(self, fake):
+        return core.ReadOnlyASCClient(
+            content.CandidateReadTransport(
+                fake, self.fixture.candidate, self.fixture.verified
+            )
+        )
+
+    @staticmethod
+    def asset(name, size, checksum, state="COMPLETE"):
+        return {
+            "fileName": name,
+            "fileSize": size,
+            "sourceFileChecksum": checksum,
+            "assetDeliveryState": {"state": state},
+        }
+
+    def test_a_source_named_iap_asset_binds_by_size_and_checksum(self):
+        entry = self.fixture.verified[self.IAP_PATH]
+        bound = self.transport(self.fixture.verified)._match_asset(
+            self.asset(content.SOURCE_FILENAME_SENTINEL, entry["bytes"], entry["md5"]),
+            "in-app purchase com.example.cloud.monthly",
+            allow_source_filename=True,
+        )
+        self.assertEqual(bound["path"], self.IAP_PATH)
+        self.assertEqual(bound["sha256"], entry["sha256"])
+
+    def test_a_full_read_binds_source_named_subscription_screenshots(self):
+        fake = FakeAppStoreConnect(self.fixture)
+        for product_id in core.CLOUD_PRODUCT_IDS:
+            fake.subscriptions[product_id]["screenshot"][
+                "fileName"
+            ] = content.SOURCE_FILENAME_SENTINEL
+        outcome = core.reconcile_authoritatively(
+            self.fixture.manifest, self.client(fake)
+        )
+        self.assertEqual(outcome.outcome, "matching_draft")
+        self.assertEqual(fake.writes, [])
+
+    def test_a_source_name_is_not_relaxed_without_the_flag(self):
+        entry = self.fixture.verified[self.IAP_PATH]
+        with self.assertRaises(asc_read.AppStoreConnectError) as caught:
+            self.transport(self.fixture.verified)._match_asset(
+                self.asset(
+                    content.SOURCE_FILENAME_SENTINEL, entry["bytes"], entry["md5"]
+                ),
+                "screenshot APP_IPHONE_67",
+            )
+        self.assertIn("does not match exactly one approved file", str(caught.exception))
+
+    def test_a_listing_asset_still_binds_by_name_size_and_checksum(self):
+        entry = self.fixture.verified[self.LISTING_PATH]
+        bound = self.transport(self.fixture.verified)._match_asset(
+            self.asset(entry["name"], entry["bytes"], entry["md5"]),
+            "screenshot APP_IPHONE_67",
+        )
+        self.assertEqual(bound["path"], self.LISTING_PATH)
+
+    def test_a_listing_asset_with_a_wrong_name_still_refuses(self):
+        entry = self.fixture.verified[self.LISTING_PATH]
+        with self.assertRaises(asc_read.AppStoreConnectError) as caught:
+            self.transport(self.fixture.verified)._match_asset(
+                self.asset("not-the-approved-name.png", entry["bytes"], entry["md5"]),
+                "screenshot APP_IPHONE_67",
+            )
+        self.assertIn("does not match exactly one approved file", str(caught.exception))
+
+    def test_a_real_iap_name_that_differs_is_not_relaxed(self):
+        entry = self.fixture.verified[self.IAP_PATH]
+        with self.assertRaises(asc_read.AppStoreConnectError) as caught:
+            self.transport(self.fixture.verified)._match_asset(
+                self.asset("a-real-but-wrong-name.png", entry["bytes"], entry["md5"]),
+                "in-app purchase com.example.cloud.monthly",
+                allow_source_filename=True,
+            )
+        self.assertIn("does not match exactly one approved file", str(caught.exception))
+
+    def test_a_source_asset_matching_more_than_one_file_refuses(self):
+        verified = {
+            "docs/app-store/iap/one.png": {
+                "bytes": 10,
+                "sha256": "s1",
+                "md5": "sharedmd5",
+                "name": "one.png",
+            },
+            "docs/app-store/iap/two.png": {
+                "bytes": 10,
+                "sha256": "s2",
+                "md5": "sharedmd5",
+                "name": "two.png",
+            },
+        }
+        with self.assertRaises(asc_read.AppStoreConnectError) as caught:
+            self.transport(verified)._match_asset(
+                self.asset(content.SOURCE_FILENAME_SENTINEL, 10, "sharedmd5"),
+                "in-app purchase com.example.cloud.monthly",
+                allow_source_filename=True,
+            )
+        self.assertIn("does not match exactly one approved file", str(caught.exception))
+
+    def test_a_source_asset_matching_no_file_refuses(self):
+        with self.assertRaises(asc_read.AppStoreConnectError) as caught:
+            self.transport(self.fixture.verified)._match_asset(
+                self.asset(content.SOURCE_FILENAME_SENTINEL, 999999, "0" * 32),
+                "in-app purchase com.example.cloud.monthly",
+                allow_source_filename=True,
+            )
+        self.assertIn("does not match exactly one approved file", str(caught.exception))
+
+    def test_a_source_asset_that_is_undelivered_still_refuses(self):
+        entry = self.fixture.verified[self.IAP_PATH]
+        with self.assertRaises(asc_read.AppStoreConnectError) as caught:
+            self.transport(self.fixture.verified)._match_asset(
+                self.asset(
+                    content.SOURCE_FILENAME_SENTINEL,
+                    entry["bytes"],
+                    entry["md5"],
+                    state="UPLOAD_COMPLETE",
+                ),
+                "in-app purchase com.example.cloud.monthly",
+                allow_source_filename=True,
+            )
+        self.assertIn("not fully delivered", str(caught.exception))
+
+
 class SubmissionEngineTests(FixtureCase):
     def engine(self, fake):
         return submission.SubmissionEngine(

--- a/test/app-review-pipeline-test.py
+++ b/test/app-review-pipeline-test.py
@@ -694,9 +694,8 @@ class SubscriptionReviewAssetBindingTests(FixtureCase):
     def test_a_full_read_binds_source_named_subscription_screenshots(self):
         fake = FakeAppStoreConnect(self.fixture)
         for product_id in core.CLOUD_PRODUCT_IDS:
-            fake.subscriptions[product_id]["screenshot"][
-                "fileName"
-            ] = content.SOURCE_FILENAME_SENTINEL
+            screenshot = fake.subscriptions[product_id]["screenshot"]
+            screenshot["fileName"] = content.SOURCE_FILENAME_SENTINEL
         outcome = core.reconcile_authoritatively(
             self.fixture.manifest, self.client(fake)
         )

--- a/tools/app-review/content.py
+++ b/tools/app-review/content.py
@@ -35,6 +35,13 @@ import core  # noqa: E402
 REVIEWED_LOCALE = "en-US"
 ASSET_COMPLETE = "COMPLETE"
 
+# App Store Connect stores a subscription App Review screenshot's `fileName` as
+# this literal sentinel rather than the real uploaded name, even after a correct
+# re-upload. A listing screenshot instead carries its real uploaded file name, so
+# only a subscription review asset whose name is exactly this sentinel is allowed
+# to bind by byte size and MD5 alone.
+SOURCE_FILENAME_SENTINEL = "SOURCE"
+
 
 class ContentError(core.BoundedError):
     """A bounded, nonsecret reviewed-content binding failure."""
@@ -351,7 +358,9 @@ class CandidateReadTransport:
                         asc_read.attributes(subscription), "reviewNote"
                     ),
                     "reviewScreenshot": self._match_asset(
-                        asc_read.attributes(screenshot), f"in-app purchase {product_id}"
+                        asc_read.attributes(screenshot),
+                        f"in-app purchase {product_id}",
+                        allow_source_filename=True,
                     ),
                 }
             )
@@ -387,8 +396,23 @@ class CandidateReadTransport:
             )
         return self._match_asset(found, label)
 
-    def _match_asset(self, asset: Mapping[str, Any], label: str) -> Mapping[str, Any]:
-        """Map one uploaded Apple asset back to the exact approved local file."""
+    def _match_asset(
+        self,
+        asset: Mapping[str, Any],
+        label: str,
+        *,
+        allow_source_filename: bool = False,
+    ) -> Mapping[str, Any]:
+        """Map one uploaded Apple asset back to the exact approved local file.
+
+        Identity is proven by Apple's own file name, byte size, and MD5 source
+        checksum against the same local file the manifest hashed. A subscription
+        App Review screenshot is the one exception: Apple reports its file name
+        as `SOURCE_FILENAME_SENTINEL` rather than the real uploaded name, so when
+        `allow_source_filename` is set and the name is exactly that sentinel the
+        name predicate is dropped and the asset binds on byte size and MD5 alone.
+        Exactly one approved file must still match either way.
+        """
         delivery = asset.get("assetDeliveryState")
         state = delivery.get("state") if isinstance(delivery, dict) else None
         if state != ASSET_COMPLETE:
@@ -398,10 +422,11 @@ class CandidateReadTransport:
         name = asc_read.text(asset, "fileName")
         size = asset.get("fileSize")
         checksum = asc_read.text(asset, "sourceFileChecksum")
+        match_by_source = allow_source_filename and name == SOURCE_FILENAME_SENTINEL
         matches = [
             (path, verified)
             for path, verified in self._verified_files.items()
-            if verified["name"] == name
+            if (match_by_source or verified["name"] == name)
             and verified["bytes"] == size
             and verified["md5"] == checksum
         ]


### PR DESCRIPTION
## Intent

Fix a proven GET-only-reconcile bug in the App Review pipeline: tools/app-review/content.py _match_asset failed to bind a Cloud in-app-purchase subscription REVIEW screenshot back to its approved local file, so app-review-prepare.yml failed with E_ASC_READ 'an uploaded in-app purchase com.kunchenguid.eddieswallet.cloud.monthly asset does not match exactly one approved file'.

Root cause (reproduced against live App Store Connect): _match_asset required Apple fileName == local name AND size AND md5. For LISTING screenshots Apple returns the real uploaded fileName so all three match. For a SUBSCRIPTION App Review screenshot Apple stores fileName as the literal sentinel 'SOURCE' even after a correct re-upload, so the name comparison fails and zero files match. The uploaded IAP asset's size and md5 match the committed file exactly.

Fix: _match_asset now takes a keyword-only allow_source_filename flag (default False). _in_app_purchases passes it True; _reviewed_asset (listing) keeps the default False. Only when the flag is set AND fileName == the named constant SOURCE_FILENAME_SENTINEL is the name predicate dropped so the asset binds by size+md5 alone; otherwise the strict name+size+md5 predicate stands. Safety preserved: still requires EXACTLY ONE matching approved file (ambiguous/zero still raise the same bounded AppStoreConnectError), listing matching unchanged, COMPLETE delivery check stays, a real IAP filename that merely differs is NOT relaxed, sentinel not broadened. Sentinel is a named constant. Regression tests added in test/app-review-pipeline-test.py (SubscriptionReviewAssetBindingTests) assert observable behavior; confirmed fail pre-fix with the exact error, pass post-fix.

STRICT SCOPE (per captain): change ONLY tools/app-review/content.py and test/app-review-pipeline-test.py. Do NOT edit docs/app-store-configuration.md or any doc - PR 80 already made that identical change on main; a docs edit here causes a merge conflict, so the document step is intentionally skipped. Do NOT touch product code, sim wrapper, .github/, the manifest, or core.py's schema. Do NOT touch App Store Connect and submit nothing (App Review is HELD). Captain owns the merge. Branch is rebased onto latest origin/main (the docs commit was dropped).

## What Changed

- Allow subscription App Review screenshots named `SOURCE` by Apple to bind to exactly one approved file using size and MD5, while preserving strict filename matching for other assets.
- Add regression coverage for successful reconciliation, listing screenshot strictness, ambiguous or missing matches, incorrect IAP filenames, and incomplete delivery.

## Risk Assessment

✅ Low: The narrowly scoped change preserves strict listing matching and delivery checks while relaxing only SOURCE-named subscription assets to unique size-and-MD5 matching, with behavioral regression coverage for success and refusal paths.

## Testing

Inspected the scoped diff, ran the focused subscription asset regression suite, and captured an end-to-end fake App Store Connect reconciliation showing both SOURCE-named Cloud screenshots produce `matching_draft` with no writes while listing and non-sentinel filename mismatches remain rejected.

<details>
<summary>Evidence: SOURCE sentinel authoritative reconciliation evidence</summary>

Source: [SOURCE sentinel authoritative reconciliation evidence](https://github.com/kunchenguid/eddies-wallet/blob/01dcbac9672063e6c02f752cb7d82b3bd62d941f/.no-mistakes/evidence/fm/eddies-appreview-iap-source-match-fix-r1/source-sentinel-reconciliation.json)

```text
{
  "outcome": "matching_draft",
  "safety_checks": {
    "SOURCE_listing_filename_without_opt_in_refused": "an uploaded screenshot APP_IPHONE_67 asset does not match exactly one approved file",
    "different_real_iap_filename_refused": "an uploaded in-app purchase com.kunchenguid.eddieswallet.cloud.monthly asset does not match exactly one approved file"
  },
  "scenario": "GET-only authoritative reconciliation with both Cloud subscription review screenshots reported by Apple as SOURCE",
  "subscription_file_names": {
    "com.kunchenguid.eddieswallet.cloud.annual": "SOURCE",
    "com.kunchenguid.eddieswallet.cloud.monthly": "SOURCE"
  },
  "writes": []
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"d93a618ef2bdbfed86df29c9b01887c4e69ed57d","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"skipped"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --name-only a058508eb8869b08190921277c16816851d1264d..13b6b7b4871afa145cb5c1f69252293f48235126` confirmed the strict two-file scope.</code>
- <code>`python3 test/app-review-pipeline-test.py SubscriptionReviewAssetBindingTests` exercised SOURCE binding, full authoritative reconciliation, strict listing behavior, wrong-name refusal, ambiguity, zero matches, and incomplete delivery.</code>
- <code>Executed a fixture-backed GET-only authoritative reconciliation with both Cloud subscription screenshots named `SOURCE`, recording the outcome, write activity, and strict-name safety checks in the evidence JSON.</code>

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
