### PR TITLE
diagnostics(app-review): cover submit-only reviewSubmissions read in the 400 diagnostic

### DIFF
--- a/tools/app-review/diagnose_submit_reads.py
+++ b/tools/app-review/diagnose_submit_reads.py
@@ -8,16 +8,30 @@ body, so the offending `errors[]` code/title/detail is invisible. The GET-only
 prepare/demo-preflight reconcile passes green, which places the 400 in a
 submit-specific read that preflight never issues.
 
-This script reissues exactly the submit-phase reads that
-`submission.SubmissionEngine._align_candidate()` performs, in the same order,
-each wrapped in its own labeled try/except, and - unlike the production client -
+This script reissues exactly the submit-phase reads, in the same order, each
+wrapped in its own labeled try/except, and - unlike the production client -
 reads and prints Apple's raw `errors[]` on an HTTP error so the 400 can be
-root-caused.
+root-caused. It covers:
+
+  * the three `SubmissionEngine._align_candidate()` reads (version resource,
+    bound build, review detail) - already GET-clean per an earlier run;
+  * the submit-only `_open_submissions()` read of `/v1/reviewSubmissions`,
+    which neither preflight nor the earlier diagnostic exercised, and which is
+    the prime suspect: its `filter[platform]` may be unsupported on that
+    collection and return a 400;
+  * the same `/v1/reviewSubmissions` read with `filter[platform]` removed, to
+    prove directly whether dropping it makes Apple return 200 (the hypothesised
+    fix);
+  * the content-reconcile reads, driven through the real
+    `content.CandidateReadTransport` / `collect_content` path exactly as
+    `SubmissionEngine.run()` reconciles, so a 400 anywhere in that path is
+    captured too.
 
 Hard safety, non-negotiable, this handles a live credential:
   * It is GET-only. It imports neither `asc_write` nor `submission` (which
-    imports the mutation boundary). It reconstructs the read queries inline from
-    `core` constants instead. It submits nothing; App Review is HELD.
+    imports the mutation boundary). It reconstructs the submit-phase read
+    queries inline from `core` constants and from verbatim copies of
+    `submission.py` constants instead. It submits nothing; App Review is HELD.
   * It never prints, echoes, logs, or writes the API key, private key PEM,
     issuer id, key id, signed JWT/bearer token, the `Authorization` header, any
     request header, or any environment variable value. Its only output is
@@ -32,6 +46,7 @@ from pathlib import Path
 import sys
 from typing import Any, Mapping, Optional
 import urllib.error
+import urllib.parse
 import urllib.request
 
 _HERE = str(Path(__file__).resolve().parent)
@@ -39,12 +54,14 @@ if _HERE not in sys.path:
     sys.path.insert(0, _HERE)
 
 import asc_read  # noqa: E402
+import content  # noqa: E402
 import core  # noqa: E402
+import runtime  # noqa: E402
 
 VERSION = "0.1.17"
 
-# The exact submit-phase read queries, reconstructed from `core` constants so
-# this diagnostic issues byte-identical requests to
+# The exact submit-phase align-read queries, reconstructed from `core` constants
+# so this diagnostic issues byte-identical requests to
 # `submission.SubmissionEngine` without importing the mutating engine. See
 # tools/app-review/submission.py: _version_resource, _bound_build_version,
 # _align_review_detail.
@@ -57,6 +74,33 @@ VERSION_QUERY = {
 BUILD_FIELDS = {"fields[builds]": "version,expired,processingState"}
 REVIEW_DETAIL_FIELDS = {
     "fields[appStoreReviewDetails]": "notes,demoAccountRequired"
+}
+
+# Reconstructed verbatim from submission.py:40 (OPEN_SUBMISSION_STATES) and the
+# submission.py `_open_submissions()` read (submission.py:235). Copied inline,
+# not imported, because submission.py imports the mutation boundary asc_write
+# and this diagnostic must import neither asc_write nor the mutating engine.
+OPEN_SUBMISSION_STATES = (
+    "READY_FOR_REVIEW",
+    "WAITING_FOR_REVIEW",
+    "IN_REVIEW",
+    "UNRESOLVED_ISSUES",
+)
+OPEN_SUBMISSIONS_PATH = "/v1/reviewSubmissions"
+OPEN_SUBMISSIONS_QUERY = {
+    "filter[app]": core.APP_ID,
+    "filter[platform]": core.PLATFORM,
+    "filter[state]": ",".join(OPEN_SUBMISSION_STATES),
+    "fields[reviewSubmissions]": "state,platform,submitted",
+    "limit": "50",
+}
+# The same read with `filter[platform]` removed (filter[app] + filter[state]
+# only), to test the hypothesis that `filter[platform]` is not a supported
+# filter on `/v1/reviewSubmissions` and is the cause of the 400.
+OPEN_SUBMISSIONS_QUERY_NO_PLATFORM = {
+    key: value
+    for key, value in OPEN_SUBMISSIONS_QUERY.items()
+    if key != "filter[platform]"
 }
 
 
@@ -97,18 +141,81 @@ def _raw_get(
             body_bytes = error.read() or b""
         except Exception:
             body_bytes = b""
-        raise ReadFailure(_format_http_error(path, query, error.code, body_bytes))
+        raise ReadFailure(
+            _format_http_error(path, _query_string(query), error.code, body_bytes)
+        )
+
+
+class _BodyCapturingReadSession(asc_read.ReadSession):
+    """A `ReadSession` that behaves exactly like production but, on an HTTP
+    error, first captures Apple's raw `errors[]` (secret-free) before re-raising
+    the same bounded error the parent would.
+
+    The content-reconcile path (`content.CandidateReadTransport` ->
+    `collect_content` -> `core.reconcile_authoritatively`) swallows the HTTP body
+    on its way to `core.refuse`, so a plain run would hide any content-read 400.
+    By reissuing every GET through this session the reconcile runs byte-identical
+    to production, yet each HTTP error's body is recorded in `captured` and can
+    be printed afterwards. Re-raising the parent's exact error types keeps the
+    downstream transport/reconcile behavior unchanged.
+    """
+
+    def __init__(self, credential: asc_read.Credential):
+        super().__init__(credential)
+        self.captured: list[str] = []
+
+    def get_url(self, url: str) -> Mapping[str, Any]:
+        asc_read.validate_asc_url(url)
+        request = urllib.request.Request(
+            url,
+            method="GET",
+            headers={
+                "Authorization": "Bearer " + self._bearer(),
+                "Accept": "application/json",
+            },
+        )
+        try:
+            with self._opener.open(
+                request, timeout=asc_read.REQUEST_TIMEOUT_SECONDS
+            ) as response:
+                payload = json.loads(response.read())
+        except urllib.error.HTTPError as error:
+            body_bytes = b""
+            try:
+                body_bytes = error.read() or b""
+            except Exception:
+                body_bytes = b""
+            split = urllib.parse.urlsplit(url)
+            self.captured.append(
+                _format_http_error(split.path, split.query, error.code, body_bytes)
+            )
+            # Re-raise the same bounded error production would, so the transport
+            # and reconcile see identical behavior.
+            if error.code in (401, 403):
+                raise asc_read.AppStoreConnectUnauthorized(
+                    "App Store Connect refused the read credential"
+                )
+            raise asc_read.AppStoreConnectError(
+                f"App Store Connect read request failed with status {error.code}"
+            )
+        except asc_read.AppStoreConnectError:
+            raise
+        except Exception:
+            raise asc_read.AppStoreConnectError("App Store Connect read request failed")
+        if not isinstance(payload, dict):
+            raise asc_read.AppStoreConnectError("App Store Connect returned a malformed document")
+        return payload
 
 
 def _format_http_error(
-    path: str, query: Mapping[str, str], status: int, body: bytes
+    path: str, query_string: str, status: int, body: bytes
 ) -> str:
     """Render an HTTP error into a bounded, secret-free report. The request path
     and query carry no credential; the body is Apple's `errors[]` document."""
     lines = [
         f"  HTTP status: {status}",
         f"  request path: {path}",
-        f"  request query: {_query_string(query)}",
+        f"  request query: {query_string}",
     ]
     parsed: Any = None
     try:
@@ -162,6 +269,86 @@ def _resolve_version_id(payload: Mapping[str, Any]) -> Optional[str]:
     return matching[0] if len(matching) == 1 else None
 
 
+def _reviewsubmissions_read(
+    credential: asc_read.Credential,
+    step: str,
+    label: str,
+    query: Mapping[str, str],
+    failures: list[str],
+) -> bool:
+    """Issue one `/v1/reviewSubmissions` read and report it. Returns True on
+    HTTP 200, False on any HTTP error."""
+    print(f"{step} {label}: GET {OPEN_SUBMISSIONS_PATH}")
+    print(f"      query: {_query_string(query)}")
+    try:
+        _raw_get(credential, OPEN_SUBMISSIONS_PATH, query)
+        print("      SUCCESS (HTTP 200)")
+        return True
+    except ReadFailure as failure:
+        print("      FAILURE:")
+        print(str(failure))
+        failures.append(label)
+        return False
+
+
+def _run_content_reconcile(
+    credential: asc_read.Credential, failures: list[str]
+) -> None:
+    """Exercise the content-reconcile reads through the real
+    `content.CandidateReadTransport` / `collect_content` path exactly as
+    `SubmissionEngine.run()` does, capturing Apple's body on any HTTP error."""
+    print("[6/6] content_reconcile: exercising the content-reconcile reads via")
+    print("      content.CandidateReadTransport -> collect_content (real path)")
+    repo_root = Path(__file__).resolve().parents[2]
+    try:
+        manifest = runtime.load_manifest(VERSION, root=repo_root)
+        verified_files = content.verify_manifest_files(manifest, repo_root)
+    except Exception as error:
+        # A local manifest/asset problem is not the Apple 400 under
+        # investigation; report it bounded and do not count it as an HTTP read
+        # failure.
+        print(
+            "      SKIPPED: could not load the approved manifest or verify "
+            "reviewed bytes locally:"
+        )
+        print(f"        {asc_read.redact(error)}")
+        return
+
+    session = _BodyCapturingReadSession(credential)
+    transport = content.CandidateReadTransport(
+        session, manifest["candidate"], verified_files
+    )
+    client = core.ReadOnlyASCClient(transport)
+    try:
+        reconciliation = core.reconcile_authoritatively(manifest, client)
+        print(
+            "      SUCCESS: every content-reconcile read returned HTTP 200 "
+            f"(reconcile outcome: {asc_read.redact(reconciliation.outcome)})"
+        )
+    except core.AppReviewError as error:
+        if session.captured:
+            print("      FAILURE: a content-reconcile read returned an HTTP error:")
+            for report in session.captured:
+                print(report)
+            failures.append("content_reconcile")
+        else:
+            # Reconcile refused for a non-transport reason (content mismatch,
+            # absent version, and so on). That is not the 400 under
+            # investigation; report it bounded and do not count it as an HTTP
+            # read failure.
+            print(
+                "      NOTE: no content-reconcile read returned an HTTP error; "
+                "reconcile refused for a non-transport reason:"
+            )
+            print(f"        {asc_read.redact(error)}")
+    except ReadFailure as failure:
+        # Defensive: production swallows the body before this point, but if a
+        # ReadFailure ever escapes, surface it.
+        print("      FAILURE:")
+        print(str(failure))
+        failures.append("content_reconcile")
+
+
 def main() -> int:
     print("App Review submit reconcile-read diagnostic (GET-only, no secrets)")
     print(f"app: {core.APP_ID}  version: {VERSION}  platform: {core.PLATFORM}")
@@ -178,7 +365,7 @@ def main() -> int:
 
     # Step 1 - _version_resource: the appStoreVersions collection query.
     version_path = f"/v1/apps/{core.APP_ID}/appStoreVersions"
-    print(f"[1/3] version_resource: GET {version_path}")
+    print(f"[1/6] version_resource: GET {version_path}")
     print(f"      query: {_query_string(VERSION_QUERY)}")
     try:
         payload = _raw_get(credential, version_path, VERSION_QUERY)
@@ -199,11 +386,11 @@ def main() -> int:
     print()
     if version_id is None:
         print(
-            "[2/3] bound_build_version: SKIPPED (no version id from step 1)"
+            "[2/6] bound_build_version: SKIPPED (no version id from step 1)"
         )
     else:
         build_path = f"/v1/appStoreVersions/{version_id}/build"
-        print(f"[2/3] bound_build_version: GET {build_path}")
+        print(f"[2/6] bound_build_version: GET {build_path}")
         print(f"      query: {_query_string(BUILD_FIELDS)}")
         try:
             _raw_get(credential, build_path, BUILD_FIELDS)
@@ -217,11 +404,11 @@ def main() -> int:
     print()
     if version_id is None:
         print(
-            "[3/3] review_detail: SKIPPED (no version id from step 1)"
+            "[3/6] review_detail: SKIPPED (no version id from step 1)"
         )
     else:
         detail_path = f"/v1/appStoreVersions/{version_id}/appStoreReviewDetail"
-        print(f"[3/3] review_detail: GET {detail_path}")
+        print(f"[3/6] review_detail: GET {detail_path}")
         print(f"      query: {_query_string(REVIEW_DETAIL_FIELDS)}")
         try:
             _raw_get(credential, detail_path, REVIEW_DETAIL_FIELDS)
@@ -231,10 +418,53 @@ def main() -> int:
             print(str(failure))
             failures.append("review_detail")
 
+    # Step 4 - _open_submissions: the submit-only /v1/reviewSubmissions read,
+    # WITH filter[platform] - the prime suspect for the 400.
+    print()
+    open_with_platform_ok = _reviewsubmissions_read(
+        credential,
+        "[4/6]",
+        "open_submissions_with_platform",
+        OPEN_SUBMISSIONS_QUERY,
+        failures,
+    )
+
+    # Step 5 - the same read WITHOUT filter[platform], to test the hypothesised
+    # fix directly.
+    print()
+    open_without_platform_ok = _reviewsubmissions_read(
+        credential,
+        "[5/6]",
+        "open_submissions_without_platform",
+        OPEN_SUBMISSIONS_QUERY_NO_PLATFORM,
+        failures,
+    )
+
+    # Step 6 - the content-reconcile reads via the real transport.
+    print()
+    _run_content_reconcile(credential, failures)
+
     print()
     print("summary:")
+    # Report the reviewSubmissions hypothesis explicitly.
+    if not open_with_platform_ok and open_without_platform_ok:
+        print(
+            "  /v1/reviewSubmissions FAILS with filter[platform] but returns "
+            "HTTP 200 without it: dropping filter[platform] resolves the read"
+        )
+    elif not open_with_platform_ok and not open_without_platform_ok:
+        print(
+            "  /v1/reviewSubmissions FAILS both with and without "
+            "filter[platform]: removing filter[platform] does NOT resolve it"
+        )
+    elif open_with_platform_ok:
+        print(
+            "  /v1/reviewSubmissions returned HTTP 200 WITH filter[platform]: "
+            "that filter is not the cause of the 400"
+        )
+
     if failures:
-        print(f"  FAILED reads: {', '.join(failures)}")
+        print(f"  FAILED reads (HTTP error): {', '.join(failures)}")
         return 1
     if version_id is None:
         print(
@@ -242,7 +472,7 @@ def main() -> int:
             "ambiguous so the build/review-detail reads were not issued"
         )
         return 0
-    print("  all submit-phase reads returned HTTP 200")
+    print("  all issued reads returned HTTP 200")
     return 0
 
 


### PR DESCRIPTION
## What

Extend the existing GET-only App Review submit reconcile-read diagnostic
(`tools/app-review/diagnose_submit_reads.py`, already on main and already run by
`app-review-diagnose.yml`) to cover the reads it missed - the submit-only reads
where the reproducible HTTP 400 must actually live.

The prior diagnostic reissued only the three `SubmissionEngine._align_candidate()`
reads, and those all return HTTP 200. The 400 therefore hides in a submit-phase
read the diagnostic never touched. This adds, as new labelled steps:

- **`open_submissions_with_platform`** - `_open_submissions()`'s exact
  `GET /v1/reviewSubmissions` with its real `filter[app]`, `filter[platform]`,
  `filter[state]` (verbatim `OPEN_SUBMISSION_STATES`), `fields[reviewSubmissions]`,
  and `limit`. This is the prime 400 suspect: `filter[platform]` may be
  unsupported on that collection.
- **`open_submissions_without_platform`** - the same read with `filter[platform]`
  removed (keeping `filter[app]` + `filter[state]`), to test the hypothesised fix
  directly. The final summary names whether dropping `filter[platform]` turns the
  400 into a 200.
- **`content_reconcile`** - the content-reconcile reads driven through the real
  `content.CandidateReadTransport` / `collect_content` path exactly as
  `SubmissionEngine.run()` reconciles, so a 400 anywhere in that path is captured
  too. A body-capturing `ReadSession` subclass records Apple's `errors[]` before
  the production path swallows the body on its way to `core.refuse`.

## Safety (unchanged discipline)

- GET-only. Imports neither `asc_write` nor `submission` (verified: neither is in
  `sys.modules` after import). Submit-phase queries are reconstructed inline from
  `core` constants and verbatim copies of `submission.py` constants.
- Never prints the key, PEM, issuer/key id, JWT, `Authorization` header, or any
  env value. Output is only the request path+query and Apple's `errors[]` fields,
  each passed through `asc_read.redact()`.
- Does not modify `submission.py`, `submit.py`, `asc_read.py`, `core.py`,
  `content.py`, the manifest, the sim wrapper, or the `app-review-diagnose.yml`
  workflow. Touches App Store Connect not at all; submits nothing.

## Verification

- Parses/compiles; imports cleanly with no `asc_write`/`submission` loaded.
- No-credential run prints the bounded FATAL path (exit 2).
- Local content-reconcile prerequisites verified offline: repo-root resolution,
  manifest load (0.1.17 / build 18.1), and 11 reviewed files hash-match.
- Offline-simulated a 400 in the content path: the body-capturing session records
  Apple's redacted `errors[]` and the report renders as intended.

Do not merge or run yet - this is for the reviewer to confirm the no-secrets
guarantee, then merge and dispatch `app-review-diagnose.yml`.