### PR TITLE
fix(app-review): remove invalid review submission field

### DIFF
--- a/test/app-review-pipeline-test.py
+++ b/test/app-review-pipeline-test.py
@@ -486,6 +486,46 @@ def _without_id(entry):
     return {key: value for key, value in entry.items() if key != "id"}
 
 
+# Apple's documented valid fields for the reviewSubmissions resource. A
+# `fields[reviewSubmissions]` sparse-fieldset carrying anything outside this set
+# makes App Store Connect reject the whole read with HTTP 400
+# (PARAMETER_ERROR.INVALID, "'<name>' is not a valid field name") - which is the
+# 400 that blocked the submit before the `submitted` field was dropped.
+VALID_REVIEW_SUBMISSION_FIELDS = frozenset(
+    {"state", "platform", "submittedDate", "createdDate"}
+)
+
+
+class FieldValidatingAppStoreConnect(FakeAppStoreConnect):
+    """A fake that rejects an invalid `fields[reviewSubmissions]` the way Apple
+    does: any sparse-field name outside `VALID_REVIEW_SUBMISSION_FIELDS` fails
+    the whole reviewSubmissions read with the same bounded error a real HTTP 400
+    surfaces as. It validates both the `_open_submissions()` collection read and
+    the `_open_submission` readback `get`, so it guards both sites that requested
+    the invalid `submitted` field."""
+
+    def _guard_review_submission_fields(self, query):
+        raw = query.get("fields[reviewSubmissions]")
+        if raw is None:
+            return
+        requested = {field for field in raw.split(",") if field}
+        invalid = requested - VALID_REVIEW_SUBMISSION_FIELDS
+        if invalid:
+            raise asc_read.AppStoreConnectError(
+                "App Store Connect read request failed with status 400"
+            )
+
+    def get(self, path, query):
+        if re.fullmatch(r"/v1/reviewSubmissions/[^/]+", path):
+            self._guard_review_submission_fields(query)
+        return super().get(path, query)
+
+    def collection(self, path, query):
+        if path == "/v1/reviewSubmissions":
+            self._guard_review_submission_fields(query)
+        return super().collection(path, query)
+
+
 class FixtureCase(unittest.TestCase):
     def setUp(self):
         self._directory = tempfile.TemporaryDirectory()
@@ -810,6 +850,19 @@ class SubmissionEngineTests(FixtureCase):
                 "PATCH submitted",
             ],
         )
+
+    def test_open_submissions_read_uses_only_valid_review_submission_fields(self):
+        # Regression: `_open_submissions()` and the `_open_submission` readback
+        # once requested `fields[reviewSubmissions]=state,platform,submitted`,
+        # and `submitted` is not a valid reviewSubmissions field, so Apple
+        # rejected the whole read with HTTP 400 and the submit could never
+        # proceed. Drive the engine against a fake that 400s on any invalid
+        # sparse field exactly as Apple does; the read - and the whole run -
+        # must succeed, proving the query carries only valid fields.
+        fake = FieldValidatingAppStoreConnect(self.fixture)
+        outcome = self.engine(fake).run()
+        self.assertTrue(outcome.accepted)
+        self.assertIn("/v1/reviewSubmissions", fake.reads)
 
     def test_rerunning_an_accepted_submission_writes_nothing(self):
         fake = FakeAppStoreConnect(self.fixture)

--- a/tools/app-review/diagnose_submit_reads.py
+++ b/tools/app-review/diagnose_submit_reads.py
@@ -384,7 +384,7 @@ def main() -> int:
                 "or ambiguous; cannot resolve version id for steps 2-3"
             )
         else:
-            print(f"      SUCCESS (HTTP 200); resolved version id")
+            print("      SUCCESS (HTTP 200); resolved version id")
     except ReadFailure as failure:
         print("      FAILURE:")
         print(str(failure))
@@ -439,8 +439,8 @@ def main() -> int:
         failures,
     )
 
-    # Step 5 - the same read WITHOUT filter[platform], to test the hypothesised
-    # fix directly.
+    # Step 5 - the same corrected read WITHOUT filter[platform], retained to
+    # re-confirm that this filter was not the cause of the 400.
     print()
     open_without_platform_ok = _reviewsubmissions_read(
         credential,

--- a/tools/app-review/diagnose_submit_reads.py
+++ b/tools/app-review/diagnose_submit_reads.py
@@ -15,13 +15,16 @@ root-caused. It covers:
 
   * the three `SubmissionEngine._align_candidate()` reads (version resource,
     bound build, review detail) - already GET-clean per an earlier run;
-  * the submit-only `_open_submissions()` read of `/v1/reviewSubmissions`,
-    which neither preflight nor the earlier diagnostic exercised, and which is
-    the prime suspect: its `filter[platform]` may be unsupported on that
-    collection and return a 400;
-  * the same `/v1/reviewSubmissions` read with `filter[platform]` removed, to
-    prove directly whether dropping it makes Apple return 200 (the hypothesised
-    fix);
+  * the submit-only `_open_submissions()` read of `/v1/reviewSubmissions`. An
+    earlier GET-only run (31782606696) proved its 400 came from an invalid
+    `fields[reviewSubmissions]` entry (`submitted` is not a valid field name),
+    NOT from `filter[platform]`. This diagnostic now issues the CORRECTED query
+    (`fields[reviewSubmissions]=state,platform`, matching the fixed
+    `submission.py`), so a green run confirms the corrected read returns 200;
+  * the same corrected `/v1/reviewSubmissions` read with `filter[platform]`
+    removed, kept only to re-confirm that `filter[platform]` is a supported
+    filter on that collection (the corrected read must return 200 both ways),
+    since the fix deliberately keeps `filter[platform]`;
   * the content-reconcile reads, driven through the real
     `content.CandidateReadTransport` / `collect_content` path exactly as
     `SubmissionEngine.run()` reconciles, so a 400 anywhere in that path is
@@ -76,10 +79,14 @@ REVIEW_DETAIL_FIELDS = {
     "fields[appStoreReviewDetails]": "notes,demoAccountRequired"
 }
 
-# Reconstructed verbatim from submission.py:40 (OPEN_SUBMISSION_STATES) and the
-# submission.py `_open_submissions()` read (submission.py:235). Copied inline,
-# not imported, because submission.py imports the mutation boundary asc_write
-# and this diagnostic must import neither asc_write nor the mutating engine.
+# Reconstructed verbatim from submission.py's OPEN_SUBMISSION_STATES and the
+# CORRECTED `_open_submissions()` read. Copied inline, not imported, because
+# submission.py imports the mutation boundary asc_write and this diagnostic must
+# import neither asc_write nor the mutating engine. The `fields` list here MUST
+# stay identical to submission.py's `_open_submissions()` query: only valid
+# reviewSubmissions fields (Apple's set includes state, platform, submittedDate,
+# createdDate). `submitted` was invalid and caused the 400; it is dropped here
+# exactly as it was dropped in submission.py.
 OPEN_SUBMISSION_STATES = (
     "READY_FOR_REVIEW",
     "WAITING_FOR_REVIEW",
@@ -91,12 +98,13 @@ OPEN_SUBMISSIONS_QUERY = {
     "filter[app]": core.APP_ID,
     "filter[platform]": core.PLATFORM,
     "filter[state]": ",".join(OPEN_SUBMISSION_STATES),
-    "fields[reviewSubmissions]": "state,platform,submitted",
+    "fields[reviewSubmissions]": "state,platform",
     "limit": "50",
 }
-# The same read with `filter[platform]` removed (filter[app] + filter[state]
-# only), to test the hypothesis that `filter[platform]` is not a supported
-# filter on `/v1/reviewSubmissions` and is the cause of the 400.
+# The same corrected read with `filter[platform]` removed (filter[app] +
+# filter[state] only), kept to re-confirm that `filter[platform]` is a supported
+# filter on `/v1/reviewSubmissions` - the corrected read must return 200 both
+# with and without it, since the fix keeps `filter[platform]`.
 OPEN_SUBMISSIONS_QUERY_NO_PLATFORM = {
     key: value
     for key, value in OPEN_SUBMISSIONS_QUERY.items()
@@ -419,7 +427,9 @@ def main() -> int:
             failures.append("review_detail")
 
     # Step 4 - _open_submissions: the submit-only /v1/reviewSubmissions read,
-    # WITH filter[platform] - the prime suspect for the 400.
+    # the CORRECTED query (fields=state,platform, WITH filter[platform]). This
+    # is the read that 400'd on the invalid `submitted` field; a 200 here
+    # confirms the fix.
     print()
     open_with_platform_ok = _reviewsubmissions_read(
         credential,
@@ -446,21 +456,23 @@ def main() -> int:
 
     print()
     print("summary:")
-    # Report the reviewSubmissions hypothesis explicitly.
-    if not open_with_platform_ok and open_without_platform_ok:
+    # Report the corrected reviewSubmissions read explicitly. The 400 was the
+    # invalid `submitted` field, now dropped; both reads should return 200.
+    if open_with_platform_ok and open_without_platform_ok:
         print(
-            "  /v1/reviewSubmissions FAILS with filter[platform] but returns "
-            "HTTP 200 without it: dropping filter[platform] resolves the read"
+            "  corrected /v1/reviewSubmissions read returned HTTP 200 both WITH "
+            "and WITHOUT filter[platform]: the fix (dropping the invalid "
+            "`submitted` field) resolves the read and filter[platform] is fine"
         )
-    elif not open_with_platform_ok and not open_without_platform_ok:
+    elif open_with_platform_ok and not open_without_platform_ok:
         print(
-            "  /v1/reviewSubmissions FAILS both with and without "
-            "filter[platform]: removing filter[platform] does NOT resolve it"
+            "  corrected /v1/reviewSubmissions read returned HTTP 200 WITH "
+            "filter[platform] but FAILS without it (unexpected)"
         )
-    elif open_with_platform_ok:
+    else:
         print(
-            "  /v1/reviewSubmissions returned HTTP 200 WITH filter[platform]: "
-            "that filter is not the cause of the 400"
+            "  corrected /v1/reviewSubmissions read still FAILS: the invalid "
+            "`submitted` field was not the whole cause; inspect errors[] above"
         )
 
     if failures:

--- a/tools/app-review/submission.py
+++ b/tools/app-review/submission.py
@@ -239,7 +239,7 @@ class SubmissionEngine:
                 "filter[app]": core.APP_ID,
                 "filter[platform]": core.PLATFORM,
                 "filter[state]": ",".join(OPEN_SUBMISSION_STATES),
-                "fields[reviewSubmissions]": "state,platform,submitted",
+                "fields[reviewSubmissions]": "state,platform",
                 "limit": "50",
             },
         )
@@ -372,7 +372,7 @@ class SubmissionEngine:
         submission_id = submission[0]
         payload = self._read.get(
             f"/v1/reviewSubmissions/{submission_id}",
-            {"fields[reviewSubmissions]": "state,platform,submitted"},
+            {"fields[reviewSubmissions]": "state,platform"},
         )
         data = payload.get("data")
         if not isinstance(data, dict):


### PR DESCRIPTION
## Intent

Fix a proven, reproducible HTTP 400 that blocks the App Review SUBMIT. In tools/app-review/submission.py, SubmissionEngine._open_submissions() and its readback in _accept requested fields[reviewSubmissions]=state,platform,submitted on /v1/reviewSubmissions. Apple rejects the whole read with HTTP 400 (PARAMETER_ERROR.INVALID, detail "'submitted' is not a valid field name", source parameter fields[reviewSubmissions]), proven via GET-only diagnostic run 31782606696. 'submitted' is not a valid reviewSubmissions field (Apple's valid set: state, platform, submittedDate, createdDate) and the code only ever reads state, so the minimal correct fix removes 'submitted' from BOTH fields[reviewSubmissions] lists, leaving 'state,platform'. Deliberately NOT changing filters: filter[app], filter[platform], filter[state] all stay - the diagnostic proved the 400 occurs both with and without filter[platform], so filter[platform] is not the cause and must remain. No other read changed, and what the code reads (only state) is unchanged.

Regression guard added to test/app-review-pipeline-test.py: a FieldValidatingAppStoreConnect fake that rejects any fields[reviewSubmissions] name outside Apple's valid set with the same bounded error a real HTTP 400 surfaces as (mimicking Apple), validating both the collection read and the get readback. The new test drives the real SubmissionEngine.run() against it and asserts the open-submissions read and full run succeed. This is a genuine behavioral contract (not an assertion on literal query text): it fails before the fix because the query carries 'submitted' and passes after. Verified: fails pre-fix (400), passes post-fix.

Also updated tools/app-review/diagnose_submit_reads.py so its /v1/reviewSubmissions check issues the CORRECTED query (drops 'submitted', keeps state,platform and filter[platform]), so re-running the diagnostic validates the fix returns HTTP 200, and corrected its now-disproven filter[platform]-is-the-suspect narrative to reflect the real root cause. Kept the diagnostic's hard GET-only, no-secrets discipline: it still imports neither asc_write nor submission (avoiding the mutation boundary), reconstructs the query inline kept in sync with submission.py's corrected fields, and emits only Apple errors[] plus path/query via asc_read.redact - never the key/issuer/JWT/Authorization header/env.

Scope constraint: changed only submission.py, the test file, and diagnose_submit_reads.py. Did NOT modify the manifest, core.py, content.py, asc_read.py, the sim wrapper, .github/, or product code. Did NOT touch App Store Connect and submitted nothing - App Review is HELD. All three app-review test suites (pipeline 57, lanes 31, core 7) pass.

## What Changed
- Remove the invalid `submitted` field from review submission collection and acceptance readback queries.
- Update the GET-only diagnostic to validate corrected queries while retaining the platform filter.
- Add a regression test that rejects unsupported review submission fields and exercises the full submission flow.

## Risk Assessment

✅ Low: The narrowly scoped change removes the invalid field from both affected reads, preserves all required filters, and adds a behavioral regression test covering the full submission run.

## Testing

The former `submitted` field request reproduced the bounded HTTP 400, while the corrected real submission-engine flow retained all required filters, completed creation through readback, and reached `WAITING_FOR_REVIEW`; the targeted pipeline and credential-boundary suites also passed. App Store Connect was not contacted because App Review remains held.

<details>
<summary>Evidence: Submission-engine HTTP 400 reproduction and corrected accepted run</summary>

Source: [Submission-engine HTTP 400 reproduction and corrected accepted run](https://github.com/kunchenguid/eddies-wallet/blob/2db4728a3956488d0bb1f4900242b8753e182a52/.no-mistakes/evidence/fm/eddies-appreview-reviewsubmissions-fix-r1/app-review-submission-behavior.txt)

```text
FORMER REQUEST RESULT: REJECTED
bounded error: App Store Connect read request failed with status 400

CORRECTED FULL SUBMISSION RUN:
GET collection /v1/reviewSubmissions
  fields[reviewSubmissions]=state,platform
  filter[app]=6795664301
  filter[platform]=IOS
  filter[state]=READY_FOR_REVIEW,WAITING_FOR_REVIEW,IN_REVIEW,UNRESOLVED_ISSUES
GET collection /v1/reviewSubmissions
  fields[reviewSubmissions]=state,platform
  filter[app]=6795664301
  filter[platform]=IOS
  filter[state]=READY_FOR_REVIEW,WAITING_FOR_REVIEW,IN_REVIEW,UNRESOLVED_ISSUES
GET readback /v1/reviewSubmissions/rs-1
  fields[reviewSubmissions]=state,platform
accepted=True
submission_state=WAITING_FOR_REVIEW
version_state=WAITING_FOR_REVIEW
writes=POST reviewSubmission -> POST versionItem -> POST subscriptionItem -> POST subscriptionItem -> PATCH submitted
```
</details>
<details>
<summary>Evidence: GET-only diagnostic using corrected reviewSubmissions queries</summary>

Source: [GET-only diagnostic using corrected reviewSubmissions queries](https://github.com/kunchenguid/eddies-wallet/blob/2db4728a3956488d0bb1f4900242b8753e182a52/.no-mistakes/evidence/fm/eddies-appreview-reviewsubmissions-fix-r1/diagnostic-corrected-query.txt)

```text
App Review submit reconcile-read diagnostic (GET-only, no secrets)
app: 6795664301  version: 0.1.17  platform: IOS

[1/6] version_resource: GET /v1/apps/6795664301/appStoreVersions
      query: filter[versionString]=0.1.17&filter[platform]=IOS&fields[appStoreVersions]=versionString,appVersionState,platform,releaseType,build&limit=50
      SUCCESS (HTTP 200); resolved version id

[2/6] bound_build_version: GET /v1/appStoreVersions/version-1/build
      query: fields[builds]=version,expired,processingState
      SUCCESS (HTTP 200)

[3/6] review_detail: GET /v1/appStoreVersions/version-1/appStoreReviewDetail
      query: fields[appStoreReviewDetails]=notes,demoAccountRequired
      SUCCESS (HTTP 200)

[4/6] open_submissions_with_platform: GET /v1/reviewSubmissions
      query: filter[app]=6795664301&filter[platform]=IOS&filter[state]=READY_FOR_REVIEW,WAITING_FOR_REVIEW,IN_REVIEW,UNRESOLVED_ISSUES&fields[reviewSubmissions]=state,platform&limit=50
      SUCCESS (HTTP 200)

[5/6] open_submissions_without_platform: GET /v1/reviewSubmissions
      query: filter[app]=6795664301&filter[state]=READY_FOR_REVIEW,WAITING_FOR_REVIEW,IN_REVIEW,UNRESOLVED_ISSUES&fields[reviewSubmissions]=state,platform&limit=50
      SUCCESS (HTTP 200)

[6/6] content_reconcile: simulated HTTP 200 for offline validation

summary:
  corrected /v1/reviewSubmissions read returned HTTP 200 both WITH and WITHOUT filter[platform]: the fix (dropping the invalid `submitted` field) resolves the read and filter[platform] is fine
  all issued reads returned HTTP 200
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"92922fa3a65637dc81fb6064c58044403ed7bd2a","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `python3 test/app-review-pipeline-test.py SubmissionEngineTests.test_open_submissions_read_uses_only_valid_review_submission_fields`
- `python3 test/app-review-pipeline-test.py`
- `python3 test/app-review-lanes-test.py`
- <code>Executed the real `SubmissionEngine.run()` against `FieldValidatingAppStoreConnect`, reproducing the former HTTP 400 and recording the corrected collection reads, readback, filters, writes, and accepted state.</code>
- <code>Executed `diagnose_submit_reads.main()` through a simulated GET-only Apple boundary that rejects invalid review-submission fields and recorded its corrected queries and summary.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
