### PR TITLE
chore(app-review): re-approve 0.1.17 manifest onto the reviewSubmissions fix

### DIFF
--- a/tools/app-review/manifests/0.1.17.json
+++ b/tools/app-review/manifests/0.1.17.json
@@ -117,11 +117,11 @@
   "approval": {
     "approved": true,
     "approvedBy": "kunchenguid",
-    "approvedUtc": "2026-08-14T02:28:07Z",
+    "approvedUtc": "2026-08-14T08:53:54Z",
     "statement": "Generated from live App Store Connect GET readback plus committed 0.1.17 screenshot and IAP review-screenshot bytes. Apple stores Cloud IAP review screenshots as fileName SOURCE; those two assets were bound by size and MD5 to the committed iPhone 6.9 priced shot. Not submitted."
   },
   "binding": {
     "algorithm": "eddies-wallet-app-review-manifest-v1",
-    "manifestHash": "ec04ddb3927fa79ad5d2173de53aba402d4deaad1e5790881f5a693d3018772c"
+    "manifestHash": "91517198be5ad1febf81fd3811e261f96f93f378d47c9f4f84d97e7f082fd40b"
   }
 }


### PR DESCRIPTION
## Summary
- Mechanical re-approval of the existing captain-approved 0.1.17 App Review manifest. `contentHash` is unchanged (`d915ed497063e0b0a157a94c196d090baef1c0f475d4bad8ff56fcb144e7c77b`); only `approval.approvedUtc` is restamped and `binding.manifestHash` recomputed to `91517198be5ad1febf81fd3811e261f96f93f378d47c9f4f84d97e7f082fd40b`.
- The App Review pipeline pins to `git log -1 -- tools/app-review/manifests/0.1.17.json` and checks out the whole tree there. The previous pin was PR #82, before the reviewSubmissions 400 fix in `3007637` (PR #86). This re-commit moves that pin onto the fix so submit uses the corrected `submission.py`.
- No listing copy, screenshots, IAP data, review notes, or candidate fields changed. App Review remains HELD; this PR does not submit.

## Test plan
- [x] `git diff` of the manifest shows only `approvedUtc` and `manifestHash`
- [x] `core.validate_manifest`, `source_content_hash`, `manifest_binding_hash`, and `content.verify_manifest_files` all pass
- [x] Printed contentHash equals `d915ed497063e0b0a157a94c196d090baef1c0f475d4bad8ff56fcb144e7c77b`