### PR TITLE
chore(app-review): re-approve 0.1.17 manifest onto the submit-reads fix

### DIFF
--- a/tools/app-review/manifests/0.1.17.json
+++ b/tools/app-review/manifests/0.1.17.json
@@ -117,11 +117,11 @@
   "approval": {
     "approved": true,
     "approvedBy": "kunchenguid",
-    "approvedUtc": "2026-08-14T08:53:54Z",
+    "approvedUtc": "2026-08-14T19:04:09Z",
     "statement": "Generated from live App Store Connect GET readback plus committed 0.1.17 screenshot and IAP review-screenshot bytes. Apple stores Cloud IAP review screenshots as fileName SOURCE; those two assets were bound by size and MD5 to the committed iPhone 6.9 priced shot. Not submitted."
   },
   "binding": {
     "algorithm": "eddies-wallet-app-review-manifest-v1",
-    "manifestHash": "91517198be5ad1febf81fd3811e261f96f93f378d47c9f4f84d97e7f082fd40b"
+    "manifestHash": "3d593833a25ab8467b60b45592693ddeadcc798715b550255782cd037e5c3aff"
   }
 }


### PR DESCRIPTION
## Summary
- Mechanical re-approval of the existing captain-approved 0.1.17 App Review manifest. `contentHash` is unchanged (`d915ed497063e0b0a157a94c196d090baef1c0f475d4bad8ff56fcb144e7c77b`); only `approval.approvedUtc` is restamped and `binding.manifestHash` recomputed to `3d593833a25ab8467b60b45592693ddeadcc798715b550255782cd037e5c3aff`.
- The App Review pipeline pins to `git log -1 -- tools/app-review/manifests/0.1.17.json` and checks out the whole tree there. The previous pin was PR #87, before the SSHHIP-aligned submit-reads fix in `5acb230` (PR #89). This re-commit moves that pin onto the fix so submit uses the corrected `submission.py`.
- No listing copy, screenshots, IAP data, review notes, or candidate fields changed. App Review remains HELD; this PR does not submit.

## Test plan
- [x] `git diff` of the manifest shows only `approvedUtc` and `manifestHash`
- [x] `core.validate_manifest`, `source_content_hash`, and `content.verify_manifest_files` all pass
- [x] Printed contentHash equals `d915ed497063e0b0a157a94c196d090baef1c0f475d4bad8ff56fcb144e7c77b`