### PR TITLE
fix(app-review): reconcile review submission writes safely

### DIFF
--- a/docs/app-review.md
+++ b/docs/app-review.md
@@ -73,8 +73,14 @@ reconciliation outcome, and timestamp. Nothing else is recorded there.
 
 Rerunning `mode=submit` after an interruption is safe. The engine reconciles
 against authoritative Apple state first: if Apple already holds the candidate as
-submitted it performs no write and completes only the monitor handoff. It never
-replays an uncertain write, and it never creates a second review submission.
+submitted it performs no write and completes only the monitor handoff. Otherwise
+it reuses the single open review submission only when that submission is still
+reusable and contains no item or only the exact candidate; an unrelated item,
+state, or additional open submission is a conflict. After creating a submission
+or attaching the candidate, the engine reads Apple back before proceeding. A
+failed attach whose readback contains the exact candidate is complete; an absent
+candidate is a bounded failure. An uncertain create is never replayed, so a
+rerun cannot create a second review submission.
 
 If Apple accepted the submission but the monitor handoff failed, rerun the same
 dispatch. Only the handoff is outstanding, and it is a `GET`, then write, then

--- a/docs/app-store-configuration.md
+++ b/docs/app-store-configuration.md
@@ -96,7 +96,7 @@ The following remain deliberately unproven or undone:
 - The backend's In-App Purchase credential is installed and has verified the observed Sandbox notification. It remains distinct from the App Store Connect API key used for uploads; no new key is needed and none should be requested.
 - This App Store Connect configuration work did not cut a TestFlight build or merge release pull request 26. That pull request remains open and captain-owned; this task-scoped boundary does not negate the TestFlight uploads App Store Connect has already accepted for this app.
 - No submission for App Review, and no request for Apple's test notification.
-- Version `0.1.17` has build `18.1` attached and listing screenshots `COMPLETE`. No App Review submission object has been created; App Review remains HELD.
+- Version `0.1.17` has build `18.1` attached and listing screenshots `COMPLETE`. An interrupted submit attempt left one empty `READY_FOR_REVIEW` submission object with no version item attached; the version itself has not been submitted and App Review remains HELD.
 
 ### An account-policy state is not a product-discovery failure
 

--- a/test/app-review-pipeline-test.py
+++ b/test/app-review-pipeline-test.py
@@ -967,11 +967,110 @@ class SubscriptionReviewAssetBindingTests(FixtureCase):
         self.assertIn("not fully delivered", str(caught.exception))
 
 
+class ReconcileAppStoreConnect(FakeAppStoreConnect):
+    """Model Apple 409-ing an attach POST that may or may not have landed.
+
+    A real submit created a review submission and then got a `POST 409` on
+    `add_version_item`; the item genuinely landed on Apple in some runs and not
+    others. This double lets a test choose both independently so the readback
+    reconcile can be exercised for a conflict that succeeded and one that failed.
+    """
+
+    def __init__(self, *args, add_item_conflicts=False, add_item_lands=True, **overrides):
+        self.add_item_conflicts = add_item_conflicts
+        self.add_item_lands = add_item_lands
+        super().__init__(*args, **overrides)
+
+    def add_version_item(self, submission_id, version_id):
+        if not self.add_item_conflicts:
+            return super().add_version_item(submission_id, version_id)
+        self.writes.append("POST versionItem")
+        if self.add_item_lands:
+            self._next += 1
+            self.review_submissions[submission_id]["items"].append(
+                {"id": f"item-{self._next}", "appStoreVersion": version_id}
+            )
+        raise asc_read.AppStoreConnectError(
+            "App Store Connect POST was rejected with status 409"
+        )
+
+
 class SubmissionEngineTests(FixtureCase):
     def engine(self, fake):
         return submission.SubmissionEngine(
             fake, fake, self.fixture.manifest, self.fixture.verified
         )
+
+    def test_an_empty_ready_submission_is_reused_not_recreated(self):
+        # The proven leftover on App Store Connect: an empty `READY_FOR_REVIEW`
+        # review submission with no items. SSHHIP's `reconcileSubmission` reuses
+        # it in place and attaches the candidate rather than POSTing a second
+        # submission and accumulating another empty leftover.
+        fake = FakeAppStoreConnect(
+            self.fixture,
+            reviewSubmissions={
+                "rs-leftover": {"state": "READY_FOR_REVIEW", "items": []}
+            },
+        )
+        outcome = self.engine(fake).run()
+        self.assertTrue(outcome.accepted)
+        self.assertNotIn(
+            "POST reviewSubmission",
+            fake.writes,
+            "an existing open submission must be reused, never recreated",
+        )
+        self.assertEqual(fake.writes.count("POST versionItem"), 1)
+        self.assertEqual(
+            [item["appStoreVersion"] for item in fake.review_submissions["rs-leftover"]["items"]],
+            ["ver-1"],
+        )
+
+    def test_an_attach_conflict_whose_item_landed_is_treated_as_success(self):
+        # SSHHIP's `createReviewItem`: a `POST 409` on the attach whose readback
+        # shows the candidate item present means the resource actually landed, so
+        # the attach succeeded and the run submits.
+        fake = ReconcileAppStoreConnect(
+            self.fixture, add_item_conflicts=True, add_item_lands=True
+        )
+        outcome = self.engine(fake).run()
+        self.assertTrue(outcome.accepted)
+        self.assertIn("POST versionItem", fake.writes)
+        self.assertIn(
+            "PATCH submitted",
+            fake.writes,
+            "a 409 whose item landed must not block the submit",
+        )
+        self.assertEqual(outcome.submission_state, "WAITING_FOR_REVIEW")
+
+    def test_an_attach_conflict_whose_item_is_absent_still_fails(self):
+        # The other side of the readback reconcile: an attach error whose readback
+        # proves the item genuinely absent is a real failure, never smoothed over.
+        fake = ReconcileAppStoreConnect(
+            self.fixture, add_item_conflicts=True, add_item_lands=False
+        )
+        with self.assertRaises(submission.SubmissionError) as caught:
+            self.engine(fake).run()
+        self.assertIn("did not attach the approved candidate", str(caught.exception))
+        self.assertNotIn("PATCH submitted", fake.writes)
+
+    def test_a_ready_submission_targeting_another_version_is_a_conflict(self):
+        # An open submission that already carries a single item for a DIFFERENT
+        # version is a genuine conflict for the captain, not a base to attach the
+        # candidate onto - so it is surfaced and nothing is submitted.
+        fake = FakeAppStoreConnect(
+            self.fixture,
+            reviewSubmissions={
+                "rs-other": {
+                    "state": "READY_FOR_REVIEW",
+                    "items": [{"id": "item-x", "appStoreVersion": "ver-other"}],
+                }
+            },
+        )
+        with self.assertRaises(submission.SubmissionError) as caught:
+            self.engine(fake).run()
+        self.assertIn("unrelated review submission", str(caught.exception))
+        self.assertNotIn("POST versionItem", fake.writes)
+        self.assertNotIn("PATCH submitted", fake.writes)
 
     def test_a_clean_candidate_is_submitted_once_and_read_back(self):
         fake = FakeAppStoreConnect(self.fixture)

--- a/test/app-review-pipeline-test.py
+++ b/test/app-review-pipeline-test.py
@@ -1072,6 +1072,22 @@ class SubmissionEngineTests(FixtureCase):
         self.assertNotIn("POST versionItem", fake.writes)
         self.assertNotIn("PATCH submitted", fake.writes)
 
+    def test_a_ready_submission_with_an_unrelated_item_is_a_conflict(self):
+        fake = FakeAppStoreConnect(
+            self.fixture,
+            reviewSubmissions={
+                "rs-other": {
+                    "state": "READY_FOR_REVIEW",
+                    "items": [{"id": "item-x", "subscription": "sub-monthly"}],
+                }
+            },
+        )
+        with self.assertRaises(submission.SubmissionError) as caught:
+            self.engine(fake).run()
+        self.assertIn("unrelated review submission", str(caught.exception))
+        self.assertNotIn("POST versionItem", fake.writes)
+        self.assertNotIn("PATCH submitted", fake.writes)
+
     def test_a_clean_candidate_is_submitted_once_and_read_back(self):
         fake = FakeAppStoreConnect(self.fixture)
         outcome = self.engine(fake).run()

--- a/test/app-review-pipeline-test.py
+++ b/test/app-review-pipeline-test.py
@@ -967,6 +967,17 @@ class SubscriptionReviewAssetBindingTests(FixtureCase):
         self.assertIn("not fully delivered", str(caught.exception))
 
 
+class MismatchedCreateReadbackAppStoreConnect(FakeAppStoreConnect):
+    def create_review_submission(self, app_id, platform):
+        created_id = super().create_review_submission(app_id, platform)
+        self.review_submissions.pop(created_id)
+        self.review_submissions["rs-concurrent"] = {
+            "state": "READY_FOR_REVIEW",
+            "items": [],
+        }
+        return created_id
+
+
 class ReconcileAppStoreConnect(FakeAppStoreConnect):
     """Model Apple 409-ing an attach POST that may or may not have landed.
 
@@ -1000,6 +1011,18 @@ class SubmissionEngineTests(FixtureCase):
         return submission.SubmissionEngine(
             fake, fake, self.fixture.manifest, self.fixture.verified
         )
+
+    def test_successful_create_refuses_a_different_readback_submission(self):
+        fake = MismatchedCreateReadbackAppStoreConnect(self.fixture)
+        with self.assertRaises(submission.SubmissionError) as caught:
+            self.engine(fake).run()
+        self.assertIn(
+            "did not return exactly the created review submission",
+            str(caught.exception),
+        )
+        self.assertIn("POST reviewSubmission", fake.writes)
+        self.assertNotIn("POST versionItem", fake.writes)
+        self.assertNotIn("PATCH submitted", fake.writes)
 
     def test_an_empty_ready_submission_is_reused_not_recreated(self):
         # The proven leftover on App Store Connect: an empty `READY_FOR_REVIEW`

--- a/tools/app-review/submission.py
+++ b/tools/app-review/submission.py
@@ -324,8 +324,8 @@ class SubmissionEngine:
             raise SubmissionError(
                 "an unrelated review submission is already in flight for this app"
             )
-        item_versions = self._item_version_ids(submission_id)
-        if item_versions and item_versions != [version_id]:
+        items = self._submission_items(submission_id)
+        if items and not self._is_only_candidate_item(items, version_id):
             raise SubmissionError(
                 "an unrelated review submission is already in flight for this app"
             )
@@ -351,20 +351,20 @@ class SubmissionEngine:
             "App Store Connect did not return exactly the created review submission"
         )
 
-    def _item_version_ids(self, submission_id: str) -> list[str]:
-        return [
-            version_id
-            for item in self._submission_items(submission_id)
-            if (
-                version_id := asc_read.linkage_id(
-                    item, "appStoreVersion", "appStoreVersions"
-                )
-            )
-            is not None
-        ]
+    @staticmethod
+    def _is_only_candidate_item(
+        items: list[Mapping[str, Any]], version_id: str
+    ) -> bool:
+        return len(items) == 1 and asc_read.linkage_id(
+            items[0], "appStoreVersion", "appStoreVersions"
+        ) == version_id
 
     def _contains_version(self, submission_id: str, version_id: str) -> bool:
-        return version_id in self._item_version_ids(submission_id)
+        return any(
+            asc_read.linkage_id(item, "appStoreVersion", "appStoreVersions")
+            == version_id
+            for item in self._submission_items(submission_id)
+        )
 
     def _attach_items(self, submission_id: str, version_id: str) -> None:
         """Attach only the candidate version, reconciling by readback.
@@ -375,17 +375,23 @@ class SubmissionEngine:
         was Apple reporting a state it already holds. Only an item that readback
         proves genuinely absent is a real failure.
         """
-        if self._item_version_ids(submission_id) == [version_id]:
+        if self._is_only_candidate_item(
+            self._submission_items(submission_id), version_id
+        ):
             return
         try:
             self._change.add_version_item(submission_id, version_id)
         except asc_read.AppStoreConnectError:
-            if self._item_version_ids(submission_id) == [version_id]:
+            if self._is_only_candidate_item(
+                self._submission_items(submission_id), version_id
+            ):
                 return
             raise SubmissionError(
                 "App Store Connect did not attach the approved candidate"
             )
-        if self._item_version_ids(submission_id) != [version_id]:
+        if not self._is_only_candidate_item(
+            self._submission_items(submission_id), version_id
+        ):
             raise SubmissionError(
                 "App Store Connect did not attach the approved candidate"
             )

--- a/tools/app-review/submission.py
+++ b/tools/app-review/submission.py
@@ -45,6 +45,13 @@ OPEN_SUBMISSION_STATES = (
     "UNRESOLVED_ISSUES",
 )
 ACCEPTED_SUBMISSION_STATES = frozenset(("WAITING_FOR_REVIEW", "IN_REVIEW"))
+# SSHHIP's proven `reconcileSubmission` reuses only a submission Apple still
+# holds open for review work. A submission in any other observed state (for
+# example `UNRESOLVED_ISSUES`) is a genuine conflict for the captain, never a
+# base this engine attaches to or duplicates around.
+REUSABLE_SUBMISSION_STATES = frozenset(
+    ("READY_FOR_REVIEW", "WAITING_FOR_REVIEW", "IN_REVIEW")
+)
 SUBSCRIPTION_ALREADY_REVIEWABLE = frozenset(
     ("WAITING_FOR_REVIEW", "IN_REVIEW", "PENDING_BINARY_APPROVAL", "APPROVED")
 )
@@ -291,44 +298,97 @@ class SubmissionEngine:
         return items
 
     def _resume_or_create_submission(self, version_id: str) -> tuple[str, str]:
+        # SSHHIP's proven `reconcileSubmission`: reuse the open review submission
+        # Apple already holds rather than POST a fresh one every attempt, so a
+        # partially-completed prior run (like an empty `READY_FOR_REVIEW`
+        # leftover) is resumed in place and never accumulates duplicates.
         open_submissions = self._open_submissions()
         if open_submissions:
-            submission = open_submissions[0]
-            state = asc_read.text(asc_read.attributes(submission), "state")
-            if state != "READY_FOR_REVIEW" and not self._contains_version(
-                submission["id"], version_id
-            ):
-                raise SubmissionError(
-                    "an unrelated review submission is already in flight for this app"
-                )
-            return submission["id"], state
-        submission_id = self._change.create_review_submission(
-            core.APP_ID, core.PLATFORM
-        )
-        readback = self._open_submissions()
-        if len(readback) != 1 or readback[0]["id"] != submission_id:
+            return self._confirm_reusable(open_submissions[0], version_id)
+        return self._create_submission(version_id)
+
+    def _confirm_reusable(
+        self, submission: Mapping[str, Any], version_id: str
+    ) -> tuple[str, str]:
+        """Prove an existing open submission is reusable for this candidate.
+
+        A submission is reusable only when Apple still holds it open for review
+        (`REUSABLE_SUBMISSION_STATES`) and it carries at most the exact candidate
+        version as its single item. Any other state, an item targeting a
+        different version, or more than one item is a genuine conflict the
+        captain resolves - never a duplicate this engine papers over.
+        """
+        submission_id = submission["id"]
+        state = asc_read.text(asc_read.attributes(submission), "state")
+        if state not in REUSABLE_SUBMISSION_STATES:
             raise SubmissionError(
-                "App Store Connect did not return exactly the created review submission"
+                "an unrelated review submission is already in flight for this app"
             )
-        return submission_id, asc_read.text(
-            asc_read.attributes(readback[0]), "state"
+        item_versions = self._item_version_ids(submission_id)
+        if item_versions and item_versions != [version_id]:
+            raise SubmissionError(
+                "an unrelated review submission is already in flight for this app"
+            )
+        return submission_id, state
+
+    def _create_submission(self, version_id: str) -> tuple[str, str]:
+        # SSHHIP's ambiguous-create handling: a create that errors may still have
+        # landed on Apple, so read back before deciding and never blindly re-POST.
+        create_error: Optional[asc_read.AppStoreConnectError] = None
+        try:
+            self._change.create_review_submission(core.APP_ID, core.PLATFORM)
+        except asc_read.AppStoreConnectError as error:
+            create_error = error
+        readback = self._open_submissions()
+        if len(readback) == 1:
+            return self._confirm_reusable(readback[0], version_id)
+        if create_error is not None:
+            raise SubmissionError(
+                "App Store Connect did not confirm the created review submission; "
+                "resume later rather than risk a duplicate"
+            )
+        raise SubmissionError(
+            "App Store Connect did not return exactly the created review submission"
         )
+
+    def _item_version_ids(self, submission_id: str) -> list[str]:
+        return [
+            version_id
+            for item in self._submission_items(submission_id)
+            if (
+                version_id := asc_read.linkage_id(
+                    item, "appStoreVersion", "appStoreVersions"
+                )
+            )
+            is not None
+        ]
 
     def _contains_version(self, submission_id: str, version_id: str) -> bool:
-        return any(
-            asc_read.linkage_id(item, "appStoreVersion", "appStoreVersions")
-            == version_id
-            for item in self._submission_items(submission_id)
-        )
+        return version_id in self._item_version_ids(submission_id)
 
     def _attach_items(self, submission_id: str, version_id: str) -> None:
-        """Attach and confirm only the candidate App Store version."""
-        if not self._contains_version(submission_id, version_id):
+        """Attach only the candidate version, reconciling by readback.
+
+        SSHHIP's proven `createReviewItem`: after the attach POST - even one Apple
+        rejects with a 409 - read the items back. If the candidate item is now
+        present the resource actually landed and the attach succeeded; the error
+        was Apple reporting a state it already holds. Only an item that readback
+        proves genuinely absent is a real failure.
+        """
+        if self._item_version_ids(submission_id) == [version_id]:
+            return
+        try:
             self._change.add_version_item(submission_id, version_id)
-            if not self._contains_version(submission_id, version_id):
-                raise SubmissionError(
-                    "App Store Connect did not attach the approved candidate"
-                )
+        except asc_read.AppStoreConnectError:
+            if self._item_version_ids(submission_id) == [version_id]:
+                return
+            raise SubmissionError(
+                "App Store Connect did not attach the approved candidate"
+            )
+        if self._item_version_ids(submission_id) != [version_id]:
+            raise SubmissionError(
+                "App Store Connect did not attach the approved candidate"
+            )
 
     def _verify_cloud_subscriptions_reviewable(self) -> None:
         """Verify Cloud subscriptions without attaching purchase-product items."""

--- a/tools/app-review/submission.py
+++ b/tools/app-review/submission.py
@@ -335,20 +335,28 @@ class SubmissionEngine:
         # SSHHIP's ambiguous-create handling: a create that errors may still have
         # landed on Apple, so read back before deciding and never blindly re-POST.
         create_error: Optional[asc_read.AppStoreConnectError] = None
+        created_submission_id: Optional[str] = None
         try:
-            self._change.create_review_submission(core.APP_ID, core.PLATFORM)
+            created_submission_id = self._change.create_review_submission(
+                core.APP_ID, core.PLATFORM
+            )
         except asc_read.AppStoreConnectError as error:
             create_error = error
         readback = self._open_submissions()
+        if create_error is None:
+            if (
+                len(readback) != 1
+                or readback[0]["id"] != created_submission_id
+            ):
+                raise SubmissionError(
+                    "App Store Connect did not return exactly the created review submission"
+                )
+            return self._confirm_reusable(readback[0], version_id)
         if len(readback) == 1:
             return self._confirm_reusable(readback[0], version_id)
-        if create_error is not None:
-            raise SubmissionError(
-                "App Store Connect did not confirm the created review submission; "
-                "resume later rather than risk a duplicate"
-            )
         raise SubmissionError(
-            "App Store Connect did not return exactly the created review submission"
+            "App Store Connect did not confirm the created review submission; "
+            "resume later rather than risk a duplicate"
         )
 
     @staticmethod


### PR DESCRIPTION
## Intent

Align Eddie's App Review submission WRITE path (tools/app-review/submission.py) to SSHHIP's proven reconcile pattern so the actual submission of 0.1.17 goes through. Captain-approved money-facing submission-engine change, same shape as the already-landed SSHHIP read alignment and the A2 subscription fix.

Proven root cause: a real submit created a review submission then got POST 409 on add_version_item. The add-item POST body is identical to SSHHIP's; the gap was in HANDLING. The old code hard-failed on the item-POST 409 (surfacing it as a raw AppStoreConnectError), and could POST a second version item onto a submission that already targeted a different version.

Two proven SSHHIP behaviours added, scoped strictly to the create/reuse + attach/reconcile write path:
1. REUSE an existing open review submission instead of creating a new one each attempt. New REUSABLE_SUBMISSION_STATES = {READY_FOR_REVIEW, WAITING_FOR_REVIEW, IN_REVIEW}. _resume_or_create_submission reuses the single open submission when one exists and only creates when none does, so the existing empty READY_FOR_REVIEW leftover is resumed in place, never duplicated (no ASC deletion needed). _confirm_reusable asserts the reused submission is in a reusable state and carries at most the exact candidate version as its single item; any other state, a different-version item, or more than one item is surfaced as a conflict (message kept as 'an unrelated review submission is already in flight for this app' to preserve the existing refusal contract/test).
2. READ-BACK-AND-RECONCILE after the item POST and after create. _attach_items now catches the attach error, reads items back, and treats a 409 whose readback shows the candidate item present as SUCCESS (the resource actually landed). Only an item readback proves genuinely absent still fails, now as a bounded SubmissionError. _create_submission reads back after create and, on an uncertain create it cannot prove, refuses safely rather than re-POSTing and risking a duplicate.

All existing safety/refusal behaviour preserved (exactly-one-open-submission, item-targets-approved-version, contact/build/notes alignment). No read queries, manifest, core.py, content.py, asc_read.py, product code, sim wrapper, .github/, or the diagnostic were touched. asc_write.py did not need a helper, so only submission.py plus the test file changed.

Regression coverage added to test/app-review-pipeline-test.py against the injected fake ASC transport, asserting observable behaviour (not source text): (a) an existing empty READY_FOR_REVIEW submission is REUSED with no second create POST and the version attached; (b) an add-item POST that returns 409 but whose readback shows the item present is treated as SUCCESS and the run submits; (c) an add-item whose readback shows the item genuinely absent still fails with no submit; (d) a READY_FOR_REVIEW submission whose single item targets a DIFFERENT version is a surfaced conflict with nothing submitted. A new ReconcileAppStoreConnect fake models a 409 whose item may or may not have landed. All three app-review suites pass (pipeline 64, core 7, lanes 31). Do NOT submit anything to App Store Connect; firstmate runs the actual submit after merge.

## What Changed

- Reuse compatible open review submissions while rejecting conflicting states, extra items, or items targeting another version.
- Read back submission creation and version attachment writes, accepting attach conflicts only when the candidate item is confirmed and refusing uncertain creates safely.
- Add regression coverage and document the reconciled retry behavior and current empty submission state.

## Risk Assessment

✅ Low: The write-path change is narrowly scoped, preserves refusal boundaries, reconciles ambiguous writes through authoritative readback, and the prior review findings are correctly resolved with behavioral coverage.

## Testing

The complete submission-engine test class passed, and an end-to-end fake App Store Connect run demonstrated safe reuse, successful 409 readback reconciliation, and refusal without submission when reconciliation fails. No screenshot was captured because this is a non-UI operational submission path, and no real App Store Connect submission was attempted.

<details>
<summary>Evidence: App Review write reconciliation behavior and observable API writes</summary>

Source: [App Review write reconciliation behavior and observable API writes](https://github.com/kunchenguid/eddies-wallet/blob/71d3db6e6de7833de790c91a7d2476971dfa53fd/.no-mistakes/evidence/fm/eddies-appreview-write-reconcile-fix-r1/app-review-write-reconcile.json)

```text
{
  "attach_409_item_absent": {
    "bounded_error": "App Store Connect did not attach the approved candidate",
    "submitted": false,
    "writes": [
      "POST reviewSubmission",
      "POST versionItem"
    ]
  },
  "attach_409_item_landed": {
    "accepted": true,
    "submission_state": "WAITING_FOR_REVIEW",
    "submitted_after_readback": true,
    "writes": [
      "POST reviewSubmission",
      "POST versionItem",
      "PATCH submitted"
    ]
  },
  "different_version_conflict": {
    "bounded_error": "an unrelated review submission is already in flight for this app",
    "submitted": false,
    "writes": []
  },
  "reuse_existing_empty_submission": {
    "accepted": true,
    "attached_versions": [
      "ver-1"
    ],
    "created_second_submission": false,
    "submission_ids": [
      "rs-leftover"
    ],
    "submission_state": "WAITING_FOR_REVIEW",
    "writes": [
      "POST versionItem",
      "PATCH submitted"
    ]
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"47f06a1d21c14c446839c70f5410e357799ba1c5","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `tools/app-review/submission.py:327` - Intent requires a reusable submission to carry &#34;at most the exact candidate version as its single item&#34; and any additional item to conflict. `_item_version_ids` discards every item without an `appStoreVersion` linkage, so a submission containing an unrelated subscription, event, or custom-page item is treated as empty, while one containing that item plus the candidate is treated as exactly `[version_id]`. `_confirm_reusable` can therefore attach to the unrelated submission, and `_attach_items` can accept the resulting multi-item state. Inspect the raw `_submission_items` collection at this shared boundary and require either zero items or exactly one item linked to the candidate, including during post-attach reconciliation.

🔧 Fix: Reject unrelated review submission items during reconciliation
1 error still open:
- 🚨 `tools/app-review/submission.py:339` - Intent requires `_create_submission` to refuse when it cannot prove the created submission. The successful POST&#39;s returned ID is discarded, and line 343 accepts any sole reusable submission found afterward. If POST creates A while a concurrent App Store Connect action creates B and readback exposes only B, the engine attaches and submits B while leaving A duplicated. Preserve the returned ID and, after a successful create, require the sole readback submission to match it. Keep sole-submission reconciliation only for the ambiguous-error path where no ID was returned.

🔧 Fix: Require created submission identity to match readback
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected the target diff for `tools/app-review/submission.py` and `test/app-review-pipeline-test.py`.</code>
- `python3 test/app-review-pipeline-test.py SubmissionEngineTests`
- `Executed the submission engine against fake App Store Connect transports for reuse, landed 409 reconciliation, absent-item refusal, and different-version conflict, recording observable writes and outcomes in JSON.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
