### PR TITLE
chore(app-review): re-approve 0.1.17 manifest onto the write-path SSHHIP-reconcile fix

### DIFF
--- a/tools/app-review/manifests/0.1.17.json
+++ b/tools/app-review/manifests/0.1.17.json
@@ -117,11 +117,11 @@
   "approval": {
     "approved": true,
     "approvedBy": "kunchenguid",
-    "approvedUtc": "2026-08-14T19:04:09Z",
+    "approvedUtc": "2026-08-14T21:33:26Z",
     "statement": "Generated from live App Store Connect GET readback plus committed 0.1.17 screenshot and IAP review-screenshot bytes. Apple stores Cloud IAP review screenshots as fileName SOURCE; those two assets were bound by size and MD5 to the committed iPhone 6.9 priced shot. Not submitted."
   },
   "binding": {
     "algorithm": "eddies-wallet-app-review-manifest-v1",
-    "manifestHash": "3d593833a25ab8467b60b45592693ddeadcc798715b550255782cd037e5c3aff"
+    "manifestHash": "1233462eb6a5bee5eedf2fa772c69f167a016c3ffee2f88ed622006e5fc746b7"
   }
 }


### PR DESCRIPTION
## Summary
- Mechanical re-approval of the existing captain-approved 0.1.17 App Review manifest. `contentHash` is unchanged (`d915ed497063e0b0a157a94c196d090baef1c0f475d4bad8ff56fcb144e7c77b`); only `approval.approvedUtc` is restamped and `binding.manifestHash` recomputed to `1233462eb6a5bee5eedf2fa772c69f167a016c3ffee2f88ed622006e5fc746b7`.
- The App Review pipeline pins to `git log -1 -- tools/app-review/manifests/0.1.17.json` and checks out the whole tree there. The previous pin was PR #90, before the write-path SSHHIP-reconcile fix in `865f053` (PR #93). This re-commit moves that pin onto the fix so submit uses the reconciled `submission.py`.
- No listing copy, screenshots, IAP data, review notes, or candidate fields changed. App Review remains HELD; this PR does not submit.

## Test plan
- [x] `git diff` of the manifest shows only `approvedUtc` and `manifestHash`
- [x] `core.validate_manifest`, `source_content_hash`, and `content.verify_manifest_files` all pass
- [x] Printed contentHash equals `d915ed497063e0b0a157a94c196d090baef1c0f475d4bad8ff56fcb144e7c77b`