### PR TITLE
ci(app-review): add a GET-only iOS version listing

### DIFF
--- a/.github/workflows/app-review-list-versions.yml
+++ b/.github/workflows/app-review-list-versions.yml
@@ -1,0 +1,42 @@
+name: App Review iOS version listing
+
+# GET-only listing of every iOS App Store version for Eddie's Wallet. It
+# prints versionString, appVersionState, appStoreState, and createdDate for
+# each row so a baseline uniqueness refusal can be classified as terminal
+# replaced rows versus two active versions. It performs NO mutation and NO
+# submission.
+#
+# Pattern matches app-review-monitor-e2e.yml: workflow_dispatch, contents:read
+# only, no issues:write, no GitHub Environment, gated to this repository and
+# main, encrypted APP_STORE_CONNECT_* mapped into one GET step.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: eddies-app-review-list-versions
+  cancel-in-progress: false
+
+jobs:
+  list:
+    name: List every iOS App Store version
+    if: github.repository == 'kunchenguid/eddies-wallet' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout trusted default branch
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: List iOS App Store versions (GET-only)
+        env:
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+        run: python3 tools/app-review/list_app_store_versions.py

--- a/test/app-review-lanes-test.py
+++ b/test/app-review-lanes-test.py
@@ -32,8 +32,14 @@ DEMO_PREFLIGHT = "app-review-demo-preflight.yml"
 EULA_APPEND = "app-review-eula-append.yml"
 MONITOR = "app-review-monitor.yml"
 MONITOR_E2E = "app-review-monitor-e2e.yml"
+LIST_VERSIONS = "app-review-list-versions.yml"
 APP_REVIEW_WORKFLOWS = (PREPARE, SUBMIT, DEMO_PREFLIGHT)
-MODELED_WORKFLOWS = APP_REVIEW_WORKFLOWS + (MONITOR, MONITOR_E2E, EULA_APPEND)
+MODELED_WORKFLOWS = APP_REVIEW_WORKFLOWS + (
+    MONITOR,
+    MONITOR_E2E,
+    EULA_APPEND,
+    LIST_VERSIONS,
+)
 SHARED_TOOL_PIN = "216a65513dbde70d04d0efd021792743f094ed77"
 FIXED_MONITOR_ENGINE_SHA = "216a65513dbde70d04d0efd021792743f094ed77"
 SUBMIT_ENGINE_PIN = "84f0317d546ffafc0fbb794a05a22a3b50ac5097"
@@ -175,6 +181,7 @@ class CredentialLaneTests(WorkflowModelCase):
                     [
                         (DEMO_PREFLIGHT, "readiness"),
                         (EULA_APPEND, "append"),
+                        (LIST_VERSIONS, "list"),
                         (MONITOR_E2E, "observe"),
                         (MONITOR, "observe"),
                         (PREPARE, "preflight"),
@@ -648,6 +655,121 @@ class LiveMonitorProofTests(WorkflowModelCase):
         self.assertIn(r"^[0-9a-f]{40}$", command)
 
 
+class ListVersionsWorkflowTests(WorkflowModelCase):
+    """GET-only iOS version listing: classify baseline uniqueness, never submit."""
+
+    def test_the_listing_is_a_trusted_default_branch_dispatch(self):
+        triggers = self.models[LIST_VERSIONS]["on"]
+        self.assertEqual(list(triggers), ["workflow_dispatch"])
+        dispatch = triggers["workflow_dispatch"]
+        inputs = dispatch.get("inputs") if isinstance(dispatch, dict) else None
+        self.assertIn(dispatch, (None, True, {}, {"inputs": None}))
+        self.assertTrue(not inputs)
+        self.assertEqual(self.models[LIST_VERSIONS]["permissions"], {"contents": "read"})
+        concurrency = self.models[LIST_VERSIONS]["concurrency"]
+        self.assertEqual(concurrency["group"], "eddies-app-review-list-versions")
+        self.assertIs(concurrency["cancel-in-progress"], False)
+        job = self.jobs(LIST_VERSIONS)["list"]
+        guard = " ".join(str(job.get("if", "")).split())
+        self.assertIn(REPOSITORY_GUARD, guard)
+        self.assertIn(DEFAULT_BRANCH_GUARD, guard)
+        self.assertEqual(job.get("permissions"), {"contents": "read"})
+        self.assertNotIn("environment", job)
+        self.assertNotIn("issues", job.get("permissions", {}))
+        self.assertNotIn("issues", self.models[LIST_VERSIONS]["permissions"])
+
+    def test_the_listing_maps_the_submit_key_into_exactly_one_get_step(self):
+        steps = steps_of(self.jobs(LIST_VERSIONS)["list"])
+        holding = [step for step in steps if secrets_of(step) & set(MUTATION_SECRETS)]
+        self.assertEqual(len(holding), 1)
+        self.assertEqual(secrets_of(holding[0]), set(MUTATION_SECRETS))
+        self.assertNotIn(VARIABLE_TOKEN, secrets_of(holding[0]))
+        self.assertNotIn(MONITOR_VARIABLE_TOKEN, secrets_of(holding[0]))
+        self.assertNotIn(SHARED_TOOL_READ_TOKEN, secrets_of(holding[0]))
+        self.assertNotIn("GITHUB_TOKEN", holding[0].get("env") or {})
+        self.assertEqual(
+            holding[0]["run"].strip(),
+            "python3 tools/app-review/list_app_store_versions.py",
+        )
+        blob = json.dumps(self.models[LIST_VERSIONS])
+        self.assertNotIn("submit.py", blob)
+        self.assertNotIn("assemble_only.js", blob)
+        self.assertNotIn("app_review_pipeline.js", blob)
+        self.assertNotIn("reviewSubmissions", blob)
+        self.assertNotIn("issues: write", blob)
+
+    def test_every_listing_action_is_pinned_and_leaves_no_git_credential(self):
+        for step in steps_of(self.jobs(LIST_VERSIONS)["list"]):
+            uses = step.get("uses")
+            if uses:
+                self.assertRegex(uses, PINNED_ACTION)
+            if str(step.get("uses", "")).startswith("actions/checkout@"):
+                self.assertIs(step["with"]["persist-credentials"], False)
+
+
+class ListVersionsScriptTests(unittest.TestCase):
+    """The listing printer reports every row a GET collection returned."""
+
+    def test_the_printer_emits_every_version_row_including_duplicates(self):
+        sys.path.insert(0, str(TOOLS))
+        self.addCleanup(sys.path.remove, str(TOOLS))
+        listing = importlib.import_module("list_app_store_versions")
+        rows = listing.rows_from(
+            [
+                {
+                    "type": "appStoreVersions",
+                    "id": "older-016",
+                    "attributes": {
+                        "versionString": "0.1.16",
+                        "appVersionState": "REPLACED_WITH_NEW_VERSION",
+                        "appStoreState": "REPLACED_WITH_NEW_VERSION",
+                        "createdDate": "2026-07-01T00:00:00Z",
+                    },
+                },
+                {
+                    "type": "appStoreVersions",
+                    "id": "live-016",
+                    "attributes": {
+                        "versionString": "0.1.16",
+                        "appVersionState": "READY_FOR_SALE",
+                        "appStoreState": "READY_FOR_SALE",
+                        "createdDate": "2026-07-02T00:00:00Z",
+                    },
+                },
+                {
+                    "type": "appStoreVersions",
+                    "id": "rejected-017",
+                    "attributes": {
+                        "versionString": "0.1.17",
+                        "appVersionState": "REJECTED",
+                        "appStoreState": "REJECTED",
+                        "createdDate": "2026-08-01T00:00:00Z",
+                    },
+                },
+            ]
+        )
+        table = listing.format_table(rows)
+        self.assertIn("count=3 writes=0 method=GET", table)
+        self.assertIn("filter[platform]=IOS", table)
+        self.assertEqual(len(rows), 3)
+        self.assertEqual(
+            [row["id"] for row in rows if row["versionString"] == "0.1.16"],
+            ["older-016", "live-016"],
+        )
+        self.assertIn(
+            "0.1.16\tREPLACED_WITH_NEW_VERSION\tREPLACED_WITH_NEW_VERSION\t2026-07-01T00:00:00Z\tolder-016",
+            table,
+        )
+        self.assertIn(
+            "0.1.16\tREADY_FOR_SALE\tREADY_FOR_SALE\t2026-07-02T00:00:00Z\tlive-016",
+            table,
+        )
+        self.assertIn(
+            "0.1.17\tREJECTED\tREJECTED\t2026-08-01T00:00:00Z\trejected-017",
+            table,
+        )
+
+
 class EulaAppendWorkflowTests(WorkflowModelCase):
     """The 3.1.2 EULA append is a bounded one-shot write, not listing-sync."""
 
@@ -727,7 +849,7 @@ class ImportBoundaryTests(unittest.TestCase):
         return set(completed.stdout.split())
 
     def test_the_read_only_entrypoints_never_load_a_mutation_module(self):
-        for entrypoint in ("prepare", "demo_preflight", "verify"):
+        for entrypoint in ("prepare", "demo_preflight", "verify", "list_app_store_versions"):
             with self.subTest(entrypoint=entrypoint):
                 loaded = self.loaded_modules(entrypoint)
                 self.assertIn("core", loaded)

--- a/test/release-checks.sh
+++ b/test/release-checks.sh
@@ -39,7 +39,7 @@ forbid_grep() {
   fi
 }
 
-WORKFLOWS=(.github/workflows/ci.yml .github/workflows/release.yml .github/workflows/release-please.yml .github/workflows/asc-build-status.yml .github/workflows/app-review-monitor.yml .github/workflows/app-review-monitor-e2e.yml .github/workflows/app-review-prepare.yml .github/workflows/app-review-submit.yml .github/workflows/app-review-demo-preflight.yml .github/workflows/app-review-eula-append.yml)
+WORKFLOWS=(.github/workflows/ci.yml .github/workflows/release.yml .github/workflows/release-please.yml .github/workflows/asc-build-status.yml .github/workflows/app-review-monitor.yml .github/workflows/app-review-monitor-e2e.yml .github/workflows/app-review-list-versions.yml .github/workflows/app-review-prepare.yml .github/workflows/app-review-submit.yml .github/workflows/app-review-demo-preflight.yml .github/workflows/app-review-eula-append.yml)
 
 # --- Workflow syntax -------------------------------------------------------
 
@@ -284,6 +284,31 @@ require_grep 'kunchenguid/app-review-submit' "$REVIEW_E2E_WORKFLOW" "review moni
 require_grep '216a65513dbde70d04d0efd021792743f094ed77' "$REVIEW_E2E_WORKFLOW" "review monitor E2E defaults to the fixed multi-submission engine SHA"
 require_grep 'actions/checkout@[0-9a-f]{40}' "$REVIEW_E2E_WORKFLOW" "review monitor E2E pins checkout immutably"
 forbid_grep 'GITHUB_TOKEN' "$REVIEW_E2E_WORKFLOW" "review monitor E2E never maps GITHUB_TOKEN"
+
+# GET-only iOS App Store version listing. Encrypted submit-key credentials,
+# one GET step, no issue write, no submit, no shared-engine mutation.
+LIST_VERSIONS_WORKFLOW=.github/workflows/app-review-list-versions.yml
+require_grep '^  workflow_dispatch:$' "$LIST_VERSIONS_WORKFLOW" "version listing has a manual trigger"
+for forbidden in 'pull_request' 'pull_request_target' 'workflow_run' 'repository_dispatch' '^  push:' '^  schedule:'; do
+  forbid_grep "$forbidden" "$LIST_VERSIONS_WORKFLOW" "version listing excludes untrusted trigger ($forbidden)"
+done
+require_grep '^  contents: read$' "$LIST_VERSIONS_WORKFLOW" "version listing needs contents read only"
+forbid_grep '^  issues: write$' "$LIST_VERSIONS_WORKFLOW" "version listing never grants issue write"
+require_grep '^concurrency:$' "$LIST_VERSIONS_WORKFLOW" "version listing serializes live reads"
+require_grep '^  group: eddies-app-review-list-versions$' "$LIST_VERSIONS_WORKFLOW" "version listing uses its own concurrency group"
+require_grep '^  cancel-in-progress: false$' "$LIST_VERSIONS_WORKFLOW" "version listing does not cancel an in-flight read"
+forbid_grep '^[[:space:]]*(actions|pull-requests|checks|id-token|packages): write' "$LIST_VERSIONS_WORKFLOW" "version listing has no extra write permissions"
+require_grep 'APP_STORE_CONNECT_KEY_ID' "$LIST_VERSIONS_WORKFLOW" "version listing reuses the existing submit key ID"
+require_grep 'APP_STORE_CONNECT_ISSUER_ID' "$LIST_VERSIONS_WORKFLOW" "version listing reuses the existing submit issuer"
+require_grep 'APP_STORE_CONNECT_API_KEY' "$LIST_VERSIONS_WORKFLOW" "version listing reuses the existing submit API key"
+forbid_grep 'ASC_REVIEW_MONITOR_' "$LIST_VERSIONS_WORKFLOW" "version listing never references a dedicated monitor credential"
+forbid_grep 'app_review_pipeline\.js' "$LIST_VERSIONS_WORKFLOW" "version listing never invokes the shared pipeline CLI"
+forbid_grep 'assemble_only\.js' "$LIST_VERSIONS_WORKFLOW" "version listing never invokes assemble-only"
+forbid_grep 'submitted:true' "$LIST_VERSIONS_WORKFLOW" "version listing never submits"
+require_grep 'list_app_store_versions\.py' "$LIST_VERSIONS_WORKFLOW" "version listing runs the GET-only listing script"
+require_grep 'actions/checkout@[0-9a-f]{40}' "$LIST_VERSIONS_WORKFLOW" "version listing pins checkout immutably"
+forbid_grep 'GITHUB_TOKEN' "$LIST_VERSIONS_WORKFLOW" "version listing never maps GITHUB_TOKEN"
+forbid_grep 'APP_REVIEW_SUBMIT_READ_TOKEN' "$LIST_VERSIONS_WORKFLOW" "version listing never checks out the shared engine"
 for retired in \
   .github/workflows/app-store-review-status.yml \
   .github/scripts/app_store_review_monitor.py \

--- a/tools/app-review/list_app_store_versions.py
+++ b/tools/app-review/list_app_store_versions.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""GET-only listing of every iOS App Store version for Eddie's Wallet.
+
+Prints every `appStoreVersion` row Apple returns for app 6795664301:
+versionString, appVersionState, appStoreState, createdDate. Pagination follows
+`links.next`. This entrypoint imports the structurally GET-only client and
+cannot construct any other HTTP method.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any, Mapping, Sequence
+
+_HERE = str(Path(__file__).resolve().parent)
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+import asc_read  # noqa: E402
+import runtime  # noqa: E402
+
+APP_ID = "6795664301"
+VERSIONS_PATH = f"/v1/apps/{APP_ID}/appStoreVersions"
+VERSIONS_FIELDS = "versionString,appVersionState,appStoreState,createdDate"
+VERSIONS_QUERY = {
+    "fields[appStoreVersions]": VERSIONS_FIELDS,
+    "filter[platform]": "IOS",
+    "limit": "200",
+}
+COLUMNS = ("versionString", "appVersionState", "appStoreState", "createdDate")
+
+
+def rows_from(items: Sequence[Mapping[str, Any]]) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for item in items:
+        if item.get("type") != "appStoreVersions":
+            continue
+        attributes = item.get("attributes")
+        if not isinstance(attributes, dict):
+            attributes = {}
+        row = {name: "" if attributes.get(name) is None else str(attributes.get(name)) for name in COLUMNS}
+        row["id"] = str(item.get("id") or "")
+        rows.append(row)
+    rows.sort(key=lambda row: (row["versionString"], row["createdDate"], row["id"]))
+    return rows
+
+
+def format_table(rows: Sequence[Mapping[str, str]]) -> str:
+    header = "versionString\tappVersionState\tappStoreState\tcreatedDate\tid"
+    lines = [
+        f"GET {VERSIONS_PATH}?fields[appStoreVersions]={VERSIONS_FIELDS}&filter[platform]=IOS&limit=200",
+        f"count={len(rows)} writes=0 method=GET",
+        header,
+    ]
+    for row in rows:
+        lines.append(
+            "\t".join(row[name] for name in (*COLUMNS, "id"))
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    runtime.heading("App Review iOS version listing")
+    session = asc_read.ReadSession(asc_read.Credential.from_environment())
+    items, _included = session.collection(VERSIONS_PATH, VERSIONS_QUERY)
+    rows = rows_from(items)
+    sys.stdout.write(format_table(rows))
+    runtime.emit(f"versions={len(rows)} mutations=0")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(runtime.run(main))


### PR DESCRIPTION
## Summary
- Add `app-review-list-versions.yml`: monitor-e2e GET-only pattern (`workflow_dispatch`, `contents: read`, repo+main gate, no `issues: write`, no Environment). Encrypted `APP_STORE_CONNECT_*` is mapped into one GET step.
- The step runs `python3 tools/app-review/list_app_store_versions.py`, which uses the structurally GET-only client to list every iOS `appStoreVersion` (`versionString`, `appVersionState`, `appStoreState`, `createdDate`) and prints every row.
- No writes, no submit, no Automic, no shared-engine change. This is so we can classify the assemble-only `baseline App Store version is not unique` refusal as (A) terminal/replaced 0.1.16 rows versus (B) two active 0.1.16 versions.

## Test plan
- [x] `python3 test/app-review-lanes-test.py`
- [x] `bash test/release-checks.sh`
- [ ] After merge: `gh-axi workflow run app-review-list-versions.yml -R kunchenguid/eddies-wallet --ref main`
- [ ] Confirm the run log lists every 0.1.16 and 0.1.17 row with `appVersionState` + `appStoreState` + `createdDate`