### PR TITLE
ci(app-review): add a GET-only App Info category listing

### DIFF
--- a/.github/workflows/app-review-list-app-info.yml
+++ b/.github/workflows/app-review-list-app-info.yml
@@ -1,0 +1,42 @@
+name: App Review App Info categories
+
+# GET-only listing of every App Info row's primary and secondary category.
+# It prints Apple's category resource ids (FINANCE, EDUCATION, PRODUCTIVITY)
+# so a first-release E_PROTECTED category mismatch can be classified against
+# tools/app-review/app-review.config.json. It performs NO mutation and NO
+# submission.
+#
+# Pattern matches app-review-list-versions.yml: workflow_dispatch,
+# contents:read only, no issues:write, no GitHub Environment, gated to this
+# repository and main, encrypted APP_STORE_CONNECT_* mapped into one GET step.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: eddies-app-review-list-app-info
+  cancel-in-progress: false
+
+jobs:
+  list:
+    name: List live App Info categories
+    if: github.repository == 'kunchenguid/eddies-wallet' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout trusted default branch
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - name: List App Info categories (GET-only)
+        env:
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+        run: python3 tools/app-review/list_app_info_categories.py

--- a/test/app-review-lanes-test.py
+++ b/test/app-review-lanes-test.py
@@ -33,12 +33,14 @@ EULA_APPEND = "app-review-eula-append.yml"
 MONITOR = "app-review-monitor.yml"
 MONITOR_E2E = "app-review-monitor-e2e.yml"
 LIST_VERSIONS = "app-review-list-versions.yml"
+LIST_APP_INFO = "app-review-list-app-info.yml"
 APP_REVIEW_WORKFLOWS = (PREPARE, SUBMIT, DEMO_PREFLIGHT)
 MODELED_WORKFLOWS = APP_REVIEW_WORKFLOWS + (
     MONITOR,
     MONITOR_E2E,
     EULA_APPEND,
     LIST_VERSIONS,
+    LIST_APP_INFO,
 )
 SHARED_TOOL_PIN = "216a65513dbde70d04d0efd021792743f094ed77"
 FIXED_MONITOR_ENGINE_SHA = "216a65513dbde70d04d0efd021792743f094ed77"
@@ -181,6 +183,7 @@ class CredentialLaneTests(WorkflowModelCase):
                     [
                         (DEMO_PREFLIGHT, "readiness"),
                         (EULA_APPEND, "append"),
+                        (LIST_APP_INFO, "list"),
                         (LIST_VERSIONS, "list"),
                         (MONITOR_E2E, "observe"),
                         (MONITOR, "observe"),
@@ -781,6 +784,193 @@ class ListVersionsScriptTests(unittest.TestCase):
         )
 
 
+class ListAppInfoWorkflowTests(WorkflowModelCase):
+    """GET-only App Info category listing: classify E_PROTECTED, never submit."""
+
+    def test_the_listing_is_a_trusted_default_branch_dispatch(self):
+        triggers = self.models[LIST_APP_INFO]["on"]
+        self.assertEqual(list(triggers), ["workflow_dispatch"])
+        dispatch = triggers["workflow_dispatch"]
+        inputs = dispatch.get("inputs") if isinstance(dispatch, dict) else None
+        self.assertIn(dispatch, (None, True, {}, {"inputs": None}))
+        self.assertTrue(not inputs)
+        self.assertEqual(self.models[LIST_APP_INFO]["permissions"], {"contents": "read"})
+        concurrency = self.models[LIST_APP_INFO]["concurrency"]
+        self.assertEqual(concurrency["group"], "eddies-app-review-list-app-info")
+        self.assertIs(concurrency["cancel-in-progress"], False)
+        job = self.jobs(LIST_APP_INFO)["list"]
+        guard = " ".join(str(job.get("if", "")).split())
+        self.assertIn(REPOSITORY_GUARD, guard)
+        self.assertIn(DEFAULT_BRANCH_GUARD, guard)
+        self.assertEqual(job.get("permissions"), {"contents": "read"})
+        self.assertNotIn("environment", job)
+        self.assertNotIn("issues", job.get("permissions", {}))
+        self.assertNotIn("issues", self.models[LIST_APP_INFO]["permissions"])
+
+    def test_the_listing_maps_the_submit_key_into_exactly_one_get_step(self):
+        steps = steps_of(self.jobs(LIST_APP_INFO)["list"])
+        holding = [step for step in steps if secrets_of(step) & set(MUTATION_SECRETS)]
+        self.assertEqual(len(holding), 1)
+        self.assertEqual(secrets_of(holding[0]), set(MUTATION_SECRETS))
+        self.assertNotIn(VARIABLE_TOKEN, secrets_of(holding[0]))
+        self.assertNotIn(MONITOR_VARIABLE_TOKEN, secrets_of(holding[0]))
+        self.assertNotIn(SHARED_TOOL_READ_TOKEN, secrets_of(holding[0]))
+        self.assertNotIn("GITHUB_TOKEN", holding[0].get("env") or {})
+        self.assertEqual(
+            holding[0]["run"].strip(),
+            "python3 tools/app-review/list_app_info_categories.py",
+        )
+        blob = json.dumps(self.models[LIST_APP_INFO])
+        self.assertNotIn("submit.py", blob)
+        self.assertNotIn("assemble_only.js", blob)
+        self.assertNotIn("app_review_pipeline.js", blob)
+        self.assertNotIn("reviewSubmissions", blob)
+        self.assertNotIn("issues: write", blob)
+
+    def test_every_listing_action_is_pinned_and_leaves_no_git_credential(self):
+        for step in steps_of(self.jobs(LIST_APP_INFO)["list"]):
+            uses = step.get("uses")
+            if uses:
+                self.assertRegex(uses, PINNED_ACTION)
+            if str(step.get("uses", "")).startswith("actions/checkout@"):
+                self.assertIs(step["with"]["persist-credentials"], False)
+
+
+class ListAppInfoScriptTests(unittest.TestCase):
+    """The printer reports every App Info row's resolved category ids."""
+
+    def setUp(self):
+        sys.path.insert(0, str(TOOLS))
+        self.addCleanup(sys.path.remove, str(TOOLS))
+        self.listing = importlib.import_module("list_app_info_categories")
+
+    def test_the_printer_resolves_relationship_ids_to_category_resource_ids(self):
+        class Session:
+            def __init__(self):
+                self.paths = []
+
+            def collection(self, path, query):
+                self.paths.append(("collection", path, dict(query)))
+                return (
+                    [
+                        {
+                            "type": "appInfos",
+                            "id": "info-live",
+                            "attributes": {"state": "READY_FOR_DISTRIBUTION"},
+                        },
+                        {
+                            "type": "appInfos",
+                            "id": "info-edit",
+                            "attributes": {"state": "PREPARE_FOR_SUBMISSION"},
+                        },
+                    ],
+                    [],
+                )
+
+            def optional_single(self, path, query):
+                self.paths.append(("optional_single", path, dict(query)))
+                mapping = {
+                    "/v1/appInfos/info-live/relationships/primaryCategory": {
+                        "type": "appCategories",
+                        "id": "EDUCATION",
+                    },
+                    "/v1/appInfos/info-live/relationships/secondaryCategory": {
+                        "type": "appCategories",
+                        "id": "PRODUCTIVITY",
+                    },
+                    "/v1/appInfos/info-edit/relationships/primaryCategory": {
+                        "type": "appCategories",
+                        "id": "FINANCE",
+                    },
+                    "/v1/appInfos/info-edit/relationships/secondaryCategory": {
+                        "type": "appCategories",
+                        "id": "PRODUCTIVITY",
+                    },
+                }
+                return mapping[path]
+
+            def get(self, path, query):
+                self.paths.append(("get", path, dict(query)))
+                identifier = path.rsplit("/", 1)[-1]
+                return {
+                    "data": {
+                        "type": "appCategories",
+                        "id": identifier,
+                        "attributes": {"platforms": ["IOS"]},
+                    }
+                }
+
+        session = Session()
+        rows = self.listing.collect_rows(session)
+        table = self.listing.format_table(rows, ("FINANCE", "PRODUCTIVITY"))
+        self.assertEqual(
+            [(method, path) for method, path, _query in session.paths if method != "collection"],
+            [
+                ("optional_single", "/v1/appInfos/info-live/relationships/primaryCategory"),
+                ("optional_single", "/v1/appInfos/info-live/relationships/secondaryCategory"),
+                ("get", "/v1/appCategories/EDUCATION"),
+                ("get", "/v1/appCategories/PRODUCTIVITY"),
+                ("optional_single", "/v1/appInfos/info-edit/relationships/primaryCategory"),
+                ("optional_single", "/v1/appInfos/info-edit/relationships/secondaryCategory"),
+                ("get", "/v1/appCategories/FINANCE"),
+                ("get", "/v1/appCategories/PRODUCTIVITY"),
+            ],
+        )
+        self.assertIn("count=2 writes=0 method=GET", table)
+        self.assertIn("configured.primary=FINANCE configured.secondary=PRODUCTIVITY", table)
+        self.assertIn(
+            "info-live\tREADY_FOR_DISTRIBUTION\tEDUCATION\tEDUCATION\tPRODUCTIVITY\tPRODUCTIVITY",
+            table,
+        )
+        self.assertIn(
+            "info-edit\tPREPARE_FOR_SUBMISSION\tFINANCE\tFINANCE\tPRODUCTIVITY\tPRODUCTIVITY",
+            table,
+        )
+        self.assertEqual(
+            self.listing.live_summary(rows),
+            "live.primary=EDUCATION,FINANCE live.secondary=PRODUCTIVITY appInfos=2",
+        )
+
+    def test_a_null_category_relationship_prints_as_empty_not_a_guess(self):
+        class Session:
+            def collection(self, path, query):
+                return (
+                    [
+                        {
+                            "type": "appInfos",
+                            "id": "info-empty",
+                            "attributes": {"state": "PREPARE_FOR_SUBMISSION"},
+                        }
+                    ],
+                    [],
+                )
+
+            def optional_single(self, path, query):
+                return None
+
+            def get(self, path, query):
+                raise AssertionError(f"must not resolve a missing category: {path}")
+
+        rows = self.listing.collect_rows(Session())
+        self.assertEqual(
+            rows,
+            [
+                {
+                    "appInfoId": "info-empty",
+                    "state": "PREPARE_FOR_SUBMISSION",
+                    "primaryId": "",
+                    "primaryName": "",
+                    "secondaryId": "",
+                    "secondaryName": "",
+                }
+            ],
+        )
+        self.assertEqual(
+            self.listing.live_summary(rows),
+            "live.primary= live.secondary= appInfos=1",
+        )
+
+
 class EulaAppendWorkflowTests(WorkflowModelCase):
     """The 3.1.2 EULA append is a bounded one-shot write, not listing-sync."""
 
@@ -860,7 +1050,13 @@ class ImportBoundaryTests(unittest.TestCase):
         return set(completed.stdout.split())
 
     def test_the_read_only_entrypoints_never_load_a_mutation_module(self):
-        for entrypoint in ("prepare", "demo_preflight", "verify", "list_app_store_versions"):
+        for entrypoint in (
+            "prepare",
+            "demo_preflight",
+            "verify",
+            "list_app_store_versions",
+            "list_app_info_categories",
+        ):
             with self.subTest(entrypoint=entrypoint):
                 loaded = self.loaded_modules(entrypoint)
                 self.assertIn("core", loaded)

--- a/test/release-checks.sh
+++ b/test/release-checks.sh
@@ -39,7 +39,7 @@ forbid_grep() {
   fi
 }
 
-WORKFLOWS=(.github/workflows/ci.yml .github/workflows/release.yml .github/workflows/release-please.yml .github/workflows/asc-build-status.yml .github/workflows/app-review-monitor.yml .github/workflows/app-review-monitor-e2e.yml .github/workflows/app-review-list-versions.yml .github/workflows/app-review-prepare.yml .github/workflows/app-review-submit.yml .github/workflows/app-review-demo-preflight.yml .github/workflows/app-review-eula-append.yml)
+WORKFLOWS=(.github/workflows/ci.yml .github/workflows/release.yml .github/workflows/release-please.yml .github/workflows/asc-build-status.yml .github/workflows/app-review-monitor.yml .github/workflows/app-review-monitor-e2e.yml .github/workflows/app-review-list-versions.yml .github/workflows/app-review-list-app-info.yml .github/workflows/app-review-prepare.yml .github/workflows/app-review-submit.yml .github/workflows/app-review-demo-preflight.yml .github/workflows/app-review-eula-append.yml)
 
 # --- Workflow syntax -------------------------------------------------------
 
@@ -309,6 +309,31 @@ require_grep 'list_app_store_versions\.py' "$LIST_VERSIONS_WORKFLOW" "version li
 require_grep 'actions/checkout@[0-9a-f]{40}' "$LIST_VERSIONS_WORKFLOW" "version listing pins checkout immutably"
 forbid_grep 'GITHUB_TOKEN' "$LIST_VERSIONS_WORKFLOW" "version listing never maps GITHUB_TOKEN"
 forbid_grep 'APP_REVIEW_SUBMIT_READ_TOKEN' "$LIST_VERSIONS_WORKFLOW" "version listing never checks out the shared engine"
+
+# GET-only App Info category listing. Encrypted submit-key credentials,
+# one GET step, no issue write, no submit, no shared-engine mutation.
+LIST_APP_INFO_WORKFLOW=.github/workflows/app-review-list-app-info.yml
+require_grep '^  workflow_dispatch:$' "$LIST_APP_INFO_WORKFLOW" "App Info listing has a manual trigger"
+for forbidden in 'pull_request' 'pull_request_target' 'workflow_run' 'repository_dispatch' '^  push:' '^  schedule:'; do
+  forbid_grep "$forbidden" "$LIST_APP_INFO_WORKFLOW" "App Info listing excludes untrusted trigger ($forbidden)"
+done
+require_grep '^  contents: read$' "$LIST_APP_INFO_WORKFLOW" "App Info listing needs contents read only"
+forbid_grep '^  issues: write$' "$LIST_APP_INFO_WORKFLOW" "App Info listing never grants issue write"
+require_grep '^concurrency:$' "$LIST_APP_INFO_WORKFLOW" "App Info listing serializes live reads"
+require_grep '^  group: eddies-app-review-list-app-info$' "$LIST_APP_INFO_WORKFLOW" "App Info listing uses its own concurrency group"
+require_grep '^  cancel-in-progress: false$' "$LIST_APP_INFO_WORKFLOW" "App Info listing does not cancel an in-flight read"
+forbid_grep '^[[:space:]]*(actions|pull-requests|checks|id-token|packages): write' "$LIST_APP_INFO_WORKFLOW" "App Info listing has no extra write permissions"
+require_grep 'APP_STORE_CONNECT_KEY_ID' "$LIST_APP_INFO_WORKFLOW" "App Info listing reuses the existing submit key ID"
+require_grep 'APP_STORE_CONNECT_ISSUER_ID' "$LIST_APP_INFO_WORKFLOW" "App Info listing reuses the existing submit issuer"
+require_grep 'APP_STORE_CONNECT_API_KEY' "$LIST_APP_INFO_WORKFLOW" "App Info listing reuses the existing submit API key"
+forbid_grep 'ASC_REVIEW_MONITOR_' "$LIST_APP_INFO_WORKFLOW" "App Info listing never references a dedicated monitor credential"
+forbid_grep 'app_review_pipeline\.js' "$LIST_APP_INFO_WORKFLOW" "App Info listing never invokes the shared pipeline CLI"
+forbid_grep 'assemble_only\.js' "$LIST_APP_INFO_WORKFLOW" "App Info listing never invokes assemble-only"
+forbid_grep 'submitted:true' "$LIST_APP_INFO_WORKFLOW" "App Info listing never submits"
+require_grep 'list_app_info_categories\.py' "$LIST_APP_INFO_WORKFLOW" "App Info listing runs the GET-only category script"
+require_grep 'actions/checkout@[0-9a-f]{40}' "$LIST_APP_INFO_WORKFLOW" "App Info listing pins checkout immutably"
+forbid_grep 'GITHUB_TOKEN' "$LIST_APP_INFO_WORKFLOW" "App Info listing never maps GITHUB_TOKEN"
+forbid_grep 'APP_REVIEW_SUBMIT_READ_TOKEN' "$LIST_APP_INFO_WORKFLOW" "App Info listing never checks out the shared engine"
 for retired in \
   .github/workflows/app-store-review-status.yml \
   .github/scripts/app_store_review_monitor.py \

--- a/tools/app-review/README.md
+++ b/tools/app-review/README.md
@@ -35,6 +35,8 @@ Store Connect. `test/release-checks.sh` runs these suites.
 | `github_api.py` | The durable issue-record boundary on `GITHUB_TOKEN`. The post-acceptance monitor-variable handoff remains in this module but is not wired into assemble-only; the captain Submit tap is outside this repository. |
 | `evidence.py` | Bounded nonsecret reviewer-path readiness evidence: built by the preflight, re-bound and freshness-checked by verify and assemble. |
 | `prepare.py`, `demo_preflight.py`, `verify.py` | The Python workflow entrypoints. Verify is credential-free. |
+| `list_app_store_versions.py` | GET-only iOS App Store version listing. |
+| `list_app_info_categories.py` | GET-only App Info primary and secondary category listing. |
 | `assemble_only.js` | Eddie's adapter onto `kunchenguid/app-review-submit`. It maps the captain-approved Eddie manifest, demo-preflight evidence, and Cloud product ids onto `runSubmission({ assembleOnly: true })`, then refuses any result other than `status: assembled` / `submitted: false`. |
 | `append_standard_eula.py` | One-shot Guideline 3.1.2 remediation: GET the 0.1.17 en-US description, append Apple's standard EULA line if absent, PATCH only that field, GET to verify. It does not import a Python write boundary. |
 

--- a/tools/app-review/list_app_info_categories.py
+++ b/tools/app-review/list_app_info_categories.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""GET-only listing of live App Info categories for Eddie's Wallet.
+
+Reads `/v1/apps/6795664301/appInfos`, then each row's primaryCategory and
+secondaryCategory relationships, then `/v1/appCategories/{id}` so the printed
+name is Apple's category resource id (FINANCE, EDUCATION, PRODUCTIVITY, ...).
+This entrypoint imports the structurally GET-only client and cannot construct
+any other HTTP method.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import sys
+from typing import Any, Mapping, Optional, Protocol, Sequence
+
+_HERE = str(Path(__file__).resolve().parent)
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+import asc_read  # noqa: E402
+import runtime  # noqa: E402
+
+APP_ID = "6795664301"
+INFOS_PATH = f"/v1/apps/{APP_ID}/appInfos"
+INFOS_QUERY = {"fields[appInfos]": "state", "limit": "20"}
+CONFIG_PATH = Path("tools/app-review/app-review.config.json")
+COLUMNS = (
+    "appInfoId",
+    "state",
+    "primaryId",
+    "primaryName",
+    "secondaryId",
+    "secondaryName",
+)
+
+
+class CategoryReadSession(Protocol):
+    def collection(
+        self, path: str, query: Mapping[str, str]
+    ) -> tuple[list[Mapping[str, Any]], list[Mapping[str, Any]]]: ...
+
+    def optional_single(
+        self, path: str, query: Mapping[str, str]
+    ) -> Optional[Mapping[str, Any]]: ...
+
+    def get(self, path: str, query: Mapping[str, str]) -> Mapping[str, Any]: ...
+
+
+def configured_categories(path: Path = CONFIG_PATH) -> tuple[str, str]:
+    document = json.loads(path.read_text())
+    protected = document["protected"]
+    return str(protected["primaryCategory"]), str(protected["secondaryCategory"])
+
+
+def _relationship_id(resource: Optional[Mapping[str, Any]]) -> str:
+    if not resource:
+        return ""
+    identifier = resource.get("id")
+    return identifier if isinstance(identifier, str) else ""
+
+
+def _category_name(payload: Mapping[str, Any], relationship_id: str) -> str:
+    data = payload.get("data")
+    if isinstance(data, dict) and data.get("type") == "appCategories":
+        identifier = data.get("id")
+        if isinstance(identifier, str) and identifier:
+            return identifier
+    return relationship_id
+
+
+def collect_rows(session: CategoryReadSession) -> list[dict[str, str]]:
+    infos, _included = session.collection(INFOS_PATH, INFOS_QUERY)
+    rows: list[dict[str, str]] = []
+    for item in infos:
+        if item.get("type") != "appInfos":
+            continue
+        info_id = str(item.get("id") or "")
+        attributes = item.get("attributes")
+        if not isinstance(attributes, dict):
+            attributes = {}
+        state = "" if attributes.get("state") is None else str(attributes.get("state"))
+        primary = session.optional_single(
+            f"/v1/appInfos/{info_id}/relationships/primaryCategory", {}
+        )
+        secondary = session.optional_single(
+            f"/v1/appInfos/{info_id}/relationships/secondaryCategory", {}
+        )
+        primary_id = _relationship_id(primary)
+        secondary_id = _relationship_id(secondary)
+        primary_name = primary_id
+        secondary_name = secondary_id
+        if primary_id:
+            primary_name = _category_name(
+                session.get(f"/v1/appCategories/{primary_id}", {}), primary_id
+            )
+        if secondary_id:
+            secondary_name = _category_name(
+                session.get(f"/v1/appCategories/{secondary_id}", {}), secondary_id
+            )
+        rows.append(
+            {
+                "appInfoId": info_id,
+                "state": state,
+                "primaryId": primary_id,
+                "primaryName": primary_name,
+                "secondaryId": secondary_id,
+                "secondaryName": secondary_name,
+            }
+        )
+    rows.sort(key=lambda row: (row["state"], row["appInfoId"]))
+    return rows
+
+
+def format_table(
+    rows: Sequence[Mapping[str, str]], configured: tuple[str, str]
+) -> str:
+    configured_primary, configured_secondary = configured
+    lines = [
+        f"GET {INFOS_PATH}?fields[appInfos]=state&limit=20",
+        f"count={len(rows)} writes=0 method=GET",
+        f"configured.primary={configured_primary} configured.secondary={configured_secondary}",
+        "\t".join(COLUMNS),
+    ]
+    for row in rows:
+        lines.append("\t".join(row[name] for name in COLUMNS))
+    return "\n".join(lines) + "\n"
+
+
+def live_summary(rows: Sequence[Mapping[str, str]]) -> str:
+    if not rows:
+        return "live.primary= live.secondary= appInfos=0"
+    primaries = sorted({row["primaryName"] for row in rows})
+    secondaries = sorted({row["secondaryName"] for row in rows})
+    return (
+        f"live.primary={','.join(primaries)} "
+        f"live.secondary={','.join(secondaries)} "
+        f"appInfos={len(rows)}"
+    )
+
+
+def main() -> int:
+    runtime.heading("App Review App Info categories")
+    session = asc_read.ReadSession(asc_read.Credential.from_environment())
+    rows = collect_rows(session)
+    configured = configured_categories()
+    sys.stdout.write(format_table(rows, configured))
+    runtime.emit(live_summary(rows))
+    runtime.emit("mutations=0")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(runtime.run(main))


### PR DESCRIPTION
## Summary
- Add `app-review-list-app-info.yml` on the list-versions pattern: `workflow_dispatch`, `contents:read`, main-only, encrypted submit key into one GET step, no writes, no submit.
- The reader GETs `/v1/apps/6795664301/appInfos`, each row's primary/secondary category relationships, then `/v1/appCategories/{id}` and prints Apple's category resource ids (FINANCE / EDUCATION / PRODUCTIVITY).
- Does not assemble, submit, or change App Store Connect.

## Test plan
- [x] `python3 test/app-review-lanes-test.py`
- [x] `test/release-checks.sh`
- [ ] After merge: `gh workflow run app-review-list-app-info.yml -R kunchenguid/eddies-wallet --ref main` and report live primary + secondary