### PR TITLE
ci: print App Review engine ASC error fields in trusted job logs

### DIFF
--- a/test/app-review-assemble-test.js
+++ b/test/app-review-assemble-test.js
@@ -220,6 +220,22 @@ async function main() {
   );
 });
 
+  await test("formatEngineError prints SafeError operation httpStatus appleCode and detail", () => {
+    const error = new Error("internal");
+    error.safeMessage = "App Store Connect rejected the bounded operation";
+    error.code = "E_API";
+    error.operation = "POST /v1/appScreenshots";
+    error.httpStatus = 409;
+    error.appleCode = "ENTITY_ERROR.RELATIONSHIP.INVALID";
+    error.detail = "The request cannot be fulfilled because of a conflict.";
+    const output = adapter.formatEngineError(error, "assemble-only failed safely");
+    assert.match(output, /code: "E_API"/);
+    assert.match(output, /operation: "POST \/v1\/appScreenshots"/);
+    assert.match(output, /httpStatus: 409/);
+    assert.match(output, /appleCode: "ENTITY_ERROR.RELATIONSHIP.INVALID"/);
+    assert.match(output, /detail: "The request cannot be fulfilled because of a conflict."/);
+  });
+
   await test("listing screenshot preflight accepts every approved display type", () => {
   const result = spawnSync("python3", ["tools/app-review/screenshot_preflight.py"], {
     cwd: ROOT,

--- a/test/app-review-upload-test.js
+++ b/test/app-review-upload-test.js
@@ -102,6 +102,42 @@ async function main() {
     assert.equal(calls[0].dependencies.monitorVariable, undefined);
   });
 
+  await test("main prints engine SafeError fields to stdout", async () => {
+    const chunks = [];
+    const write = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (chunk, encoding, callback) => {
+      chunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+      if (typeof encoding === "function") encoding();
+      if (typeof callback === "function") callback();
+      return true;
+    };
+    let exitCode;
+    try {
+      exitCode = await adapter.main(["--upload-screenshots"], {
+        runScreenshotUpload: async () => {
+          const error = new Error("internal");
+          error.safeMessage = "App Store Connect rejected the bounded operation";
+          error.code = "E_API";
+          error.operation = "POST /v1/appScreenshots";
+          error.httpStatus = 409;
+          error.appleCode = "ENTITY_ERROR.RELATIONSHIP.INVALID";
+          error.detail = "The request cannot be fulfilled because of a conflict.";
+          throw error;
+        },
+      });
+    } finally {
+      process.stdout.write = write;
+    }
+    const output = chunks.join("");
+    assert.equal(exitCode, 1);
+    assert.match(output, /code: "E_API"/);
+    assert.match(output, /operation: "POST \/v1\/appScreenshots"/);
+    assert.match(output, /message: "App Store Connect rejected the bounded operation"/);
+    assert.match(output, /httpStatus: 409/);
+    assert.match(output, /appleCode: "ENTITY_ERROR.RELATIONSHIP.INVALID"/);
+    assert.match(output, /detail: "The request cannot be fulfilled because of a conflict."/);
+  });
+
   await test("runScreenshotUpload refuses a submitted result", async () => {
     await assert.rejects(
       () => adapter.runScreenshotUpload({

--- a/tools/app-review/assemble_only.js
+++ b/tools/app-review/assemble_only.js
@@ -31,6 +31,31 @@ class AssembleError extends Error {
   }
 }
 
+function formatEngineError(error, fallbackMessage) {
+  if (error instanceof AssembleError) {
+    return `error:\n  message: ${JSON.stringify(error.message)}\n`;
+  }
+  const message = (error && error.safeMessage) || fallbackMessage;
+  const lines = ["error:"];
+  const push = (key, value) => {
+    lines.push(`  ${key}: ${typeof value === "number" ? String(value) : JSON.stringify(value)}`);
+  };
+  if (error && typeof error.code === "string" && error.code) push("code", error.code);
+  if (error && typeof error.operation === "string" && error.operation) push("operation", error.operation);
+  push("message", message);
+  if (error && Number.isInteger(error.httpStatus) && error.httpStatus > 0) push("httpStatus", error.httpStatus);
+  if (error && typeof error.appleCode === "string" && error.appleCode && error.appleCode !== "NONE") {
+    push("appleCode", error.appleCode);
+  }
+  if (error && typeof error.detail === "string" && error.detail) push("detail", error.detail);
+  return `${lines.join("\n")}\n`;
+}
+
+function writeEngineError(error, fallbackMessage) {
+  process.stdout.write(formatEngineError(error, fallbackMessage));
+  return error instanceof AssembleError ? error.exitCode : 1;
+}
+
 function fail(message, exitCode = 1) {
   throw new AssembleError(message, exitCode);
 }
@@ -512,11 +537,7 @@ async function main(argv = process.argv.slice(2)) {
     );
     return 0;
   } catch (error) {
-    const message = error instanceof AssembleError
-      ? error.message
-      : (error && error.safeMessage) || "assemble-only failed safely";
-    process.stdout.write(`error:\n  message: ${JSON.stringify(message)}\n`);
-    return error instanceof AssembleError ? error.exitCode : 1;
+    return writeEngineError(error, "assemble-only failed safely");
   }
 }
 
@@ -525,6 +546,8 @@ module.exports = {
   EULA_LINE,
   EULA_URL,
   AssembleError,
+  formatEngineError,
+  writeEngineError,
   assertAssembled,
   assertUploaded,
   assertSubmitted,

--- a/tools/app-review/full_submit.js
+++ b/tools/app-review/full_submit.js
@@ -66,11 +66,7 @@ async function main(argv = process.argv.slice(2)) {
     );
     return 0;
   } catch (error) {
-    const message = error instanceof assemble.AssembleError
-      ? error.message
-      : (error && error.safeMessage) || "full submit failed safely";
-    process.stdout.write(`error:\n  message: ${JSON.stringify(message)}\n`);
-    return error instanceof assemble.AssembleError ? error.exitCode : 1;
+    return assemble.writeEngineError(error, "full submit failed safely");
   }
 }
 

--- a/tools/app-review/upload_screenshots.js
+++ b/tools/app-review/upload_screenshots.js
@@ -87,9 +87,10 @@ async function runScreenshotUpload({
   });
 }
 
-async function main(argv = process.argv.slice(2)) {
+async function main(argv = process.argv.slice(2), deps = {}) {
+  const run = deps.runScreenshotUpload || runScreenshotUpload;
   try {
-    const uploaded = await runScreenshotUpload({ argv });
+    const uploaded = await run({ argv });
     process.stdout.write(uploaded.output);
     process.stdout.write(
       "help: Listing screenshots were uploaded without submitting. "
@@ -97,11 +98,7 @@ async function main(argv = process.argv.slice(2)) {
     );
     return 0;
   } catch (error) {
-    const message = error instanceof assemble.AssembleError
-      ? error.message
-      : (error && error.safeMessage) || "screenshot upload failed safely";
-    process.stdout.write(`error:\n  message: ${JSON.stringify(message)}\n`);
-    return error instanceof assemble.AssembleError ? error.exitCode : 1;
+    return assemble.writeEngineError(error, "screenshot upload failed safely");
   }
 }
 


### PR DESCRIPTION
## Summary
- Upload (and assemble/submit) adapters now print the engine SafeError fields `code`, `operation`, `httpStatus`, `appleCode`, and `detail` to the trusted GitHub Actions job log instead of only `safeMessage`.
- This does not recover the Apple body from failed upload run 32597293946; those fields were never written. It makes the next trusted-job failure diagnosable.

## Test plan
- [x] `node test/app-review-upload-test.js`
- [x] `node test/app-review-assemble-test.js`
- [x] `node test/app-review-full-submit-test.js`
- [ ] PR CI green
- Do not dispatch `mode=upload` or `mode=submit` from this PR.


Made with [Cursor](https://cursor.com)