### PR TITLE
ci: map existing monitor variable token onto submit engine env

### DIFF
--- a/.github/workflows/app-review-submit.yml
+++ b/.github/workflows/app-review-submit.yml
@@ -44,8 +44,9 @@ name: App Review submission
 #              listingPolicy stays observe. Opt-in is
 #              listing.screenshotWrites=true on the captain-approved manifest
 #              and config. Do not add screenshots to alignmentWrites.
-#   submit   - the same App Store Connect credentials plus
-#              APP_REVIEW_MONITOR_VARIABLE_TOKEN. It runs
+#   submit   - the same App Store Connect credentials plus the existing
+#              EDDIES_REVIEW_MONITOR_VARIABLE_TOKEN, mapped onto the engine
+#              env APP_REVIEW_MONITOR_VARIABLE_TOKEN. It runs
 #              tools/app-review/full_submit.js --submit --first-release, which
 #              calls runSubmission({ assembleOnly: false }) - the engine's real
 #              submit. After Apple accepts, the engine writes
@@ -290,8 +291,9 @@ jobs:
           persist-credentials: false
 
       # Mutation-capable App Store Connect credential plus the monitor-variable
-      # write token. This is the only job that asks the engine to submit for
-      # review. It does not invoke the shared pipeline submit subcommand
+      # write token. Map the existing Eddie secret onto the env name the
+      # engine expects. This is the only job that asks the engine to submit
+      # for review. It does not invoke the shared pipeline submit subcommand
       # (engine-shaped manifests); Eddie maps through full_submit.js onto
       # runSubmission.
       - name: Submit the review submission to Apple
@@ -299,7 +301,7 @@ jobs:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
-          APP_REVIEW_MONITOR_VARIABLE_TOKEN: ${{ secrets.APP_REVIEW_MONITOR_VARIABLE_TOKEN }}
+          APP_REVIEW_MONITOR_VARIABLE_TOKEN: ${{ secrets.EDDIES_REVIEW_MONITOR_VARIABLE_TOKEN }}
           APP_REVIEW_CONFIG: ${{ github.workspace }}/tools/app-review/app-review.config.json
           APP_REVIEW_ENGINE_DIR: ${{ github.workspace }}/.app-review-submit
           EDDIES_APP_REVIEW_VERSION: ${{ inputs.version }}

--- a/docs/app-review.md
+++ b/docs/app-review.md
@@ -222,10 +222,12 @@ and assemble/submit credential). The GET-only status monitor authenticates with
 that same key. Checkout of the private shared tool uses the already-configured
 `APP_REVIEW_SUBMIT_READ_TOKEN` (`contents:read` on `kunchenguid/app-review-submit`);
 that token is not an Apple credential and is not mapped into the assemble,
-submit, or poll steps. The gated submit job also maps
+submit, or poll steps. The gated submit job maps the existing
+`EDDIES_REVIEW_MONITOR_VARIABLE_TOKEN` secret onto the engine env
 `APP_REVIEW_MONITOR_VARIABLE_TOKEN` so the engine can write
 `APP_REVIEW_MONITOR_VERSION` after Apple accepts. Do not create a dedicated
-monitor user or any `ASC_REVIEW_MONITOR_*` secret.
+monitor user or any `ASC_REVIEW_MONITOR_*` secret. Do not add a second
+secret under the engine env name.
 
 The live scheduled monitor reads `APP_REVIEW_MONITOR_VERSION` (the exact
 marketing version). Assemble-only does not write that variable; the gated

--- a/docs/app-store-review-monitor.md
+++ b/docs/app-store-review-monitor.md
@@ -47,12 +47,13 @@ Do not create a dedicated Developer-role monitor user. Do not add `ASC_REVIEW_MO
 
 Arming is the per-app Actions variable `APP_REVIEW_MONITOR_VERSION`. Its value is the exact submitted marketing version, for example `0.1.17`. An empty or unset variable is the deliberate state between cycles: the run reports `not_armed`, contacts Apple not at all, and **succeeds**, so the schedule does not stay permanently red between cycles. A reshaped value (anything that is not a one-to-three-component numeric version) **fails visibly** rather than being guessed at.
 
-The shared config names `APP_REVIEW_MONITOR_VARIABLE_TOKEN` as the secret a
-full submit path uses to write that arming variable. This monitor workflow
-is GET-only and does not receive that token. Eddie's assemble-only job also
-does not write `APP_REVIEW_MONITOR_VERSION` or `EDDIES_REVIEW_MONITOR_CYCLE`.
-The gated `app-review-submit.yml` `mode=submit` job maps that token and the
-engine writes `APP_REVIEW_MONITOR_VERSION` after Apple accepts.
+The shared config names `APP_REVIEW_MONITOR_VARIABLE_TOKEN` as the env var a
+full submit path uses to write that arming variable. Eddie maps the existing
+`EDDIES_REVIEW_MONITOR_VARIABLE_TOKEN` secret onto that env in the gated
+`mode=submit` job. This monitor workflow is GET-only and does not receive
+that token. Eddie's assemble-only job also does not write
+`APP_REVIEW_MONITOR_VERSION` or `EDDIES_REVIEW_MONITOR_CYCLE`. After Apple
+accepts, the engine writes `APP_REVIEW_MONITOR_VERSION`.
 
 ## Verify and operate
 

--- a/test/app-review-lanes-test.py
+++ b/test/app-review-lanes-test.py
@@ -211,17 +211,18 @@ class CredentialLaneTests(WorkflowModelCase):
         holders = sorted(job for workflow, job, _ in mutating if workflow == SUBMIT)
         self.assertEqual(holders, ["assemble", "submit", "upload"])
 
-    def test_the_legacy_monitor_variable_token_is_never_mapped(self):
-        self.assertEqual(self.steps_holding(VARIABLE_TOKEN), [])
+    def test_the_nonexistent_engine_named_monitor_secret_is_never_mapped(self):
+        self.assertEqual(self.steps_holding(MONITOR_VARIABLE_TOKEN), [])
 
     def test_the_monitor_variable_token_reaches_only_the_gated_submit_job(self):
         holders = [
             (workflow, job)
-            for workflow, job, _ in self.steps_holding(MONITOR_VARIABLE_TOKEN)
+            for workflow, job, _ in self.steps_holding(VARIABLE_TOKEN)
         ]
         self.assertEqual(holders, [(SUBMIT, "submit")])
         for job_name in ("assemble", "upload"):
             for step in steps_of(self.jobs(SUBMIT)[job_name]):
+                self.assertNotIn(VARIABLE_TOKEN, secrets_of(step))
                 self.assertNotIn(MONITOR_VARIABLE_TOKEN, secrets_of(step))
 
     def test_every_verify_lane_is_credential_free(self):
@@ -649,10 +650,11 @@ class AssembleEngineTests(WorkflowModelCase):
             "${{ github.workspace }}/.app-review-submit",
         )
         self.assertNotIn("GITHUB_TOKEN", environment)
-        self.assertNotIn(VARIABLE_TOKEN, secrets_of(mutating[0]))
+        self.assertIn(VARIABLE_TOKEN, secrets_of(mutating[0]))
+        self.assertNotIn(MONITOR_VARIABLE_TOKEN, secrets_of(mutating[0]))
         self.assertEqual(
             environment["APP_REVIEW_MONITOR_VARIABLE_TOKEN"],
-            "${{ secrets.APP_REVIEW_MONITOR_VARIABLE_TOKEN }}",
+            "${{ secrets.EDDIES_REVIEW_MONITOR_VARIABLE_TOKEN }}",
         )
         self.assertEqual(
             {name: environment[name] for name in MUTATION_SECRETS},

--- a/test/release-checks.sh
+++ b/test/release-checks.sh
@@ -415,7 +415,10 @@ for workflow in "${APP_REVIEW_WORKFLOWS[@]}"; do
 done
 # app-review-lanes-test.py owns the per-step credential-lane model; these are
 # the coarse whole-file invariants that must hold however the jobs are shaped.
-forbid_grep 'EDDIES_REVIEW_MONITOR_VARIABLE_TOKEN' .github/workflows/app-review-submit.yml "assemble-only never receives the monitor variable token"
+# The existing repo secret is EDDIES_REVIEW_MONITOR_VARIABLE_TOKEN. Submit maps
+# it onto the engine env APP_REVIEW_MONITOR_VARIABLE_TOKEN; assemble, prepare,
+# and preflight never receive it.
+require_grep 'APP_REVIEW_MONITOR_VARIABLE_TOKEN: \$\{\{ secrets\.EDDIES_REVIEW_MONITOR_VARIABLE_TOKEN \}\}' .github/workflows/app-review-submit.yml "submit maps the existing Eddie monitor variable token onto the engine env"
 forbid_grep 'EDDIES_REVIEW_MONITOR_VARIABLE_TOKEN' .github/workflows/app-review-prepare.yml "preparation never receives the monitor variable token"
 forbid_grep 'EDDIES_REVIEW_MONITOR_VARIABLE_TOKEN' .github/workflows/app-review-demo-preflight.yml "the readiness preflight never receives the monitor variable token"
 require_grep 'assemble_only.js --assemble-only --first-release' .github/workflows/app-review-submit.yml "submit workflow runs Node assemble-only first-release"


### PR DESCRIPTION
## Summary
- `mode=submit` failed locally because the job mapped `secrets.APP_REVIEW_MONITOR_VARIABLE_TOKEN`, which does not exist.
- Map the existing `EDDIES_REVIEW_MONITOR_VARIABLE_TOKEN` secret onto the engine env `APP_REVIEW_MONITOR_VARIABLE_TOKEN`. Assemble and upload still never receive it. No new credential.

## Test plan
- [x] `python3 test/app-review-lanes-test.py`
- [x] `test/release-checks.sh`
- [ ] PR CI green
- After merge: dispatch `mode=submit` only (upload and assemble already succeeded for 0.1.17).


Made with [Cursor](https://cursor.com)